### PR TITLE
show the amount of selected response on bulk action

### DIFF
--- a/src/containers/ListView/index.jsx
+++ b/src/containers/ListView/index.jsx
@@ -53,6 +53,12 @@ export class ListView extends React.Component {
     this.props.loadSelectionForReview(rows.map(getSubmissionId));
   }
 
+  selectedBulkAction = (selectedFlatRows) => ({
+    buttonText: `View selected responses (${selectedFlatRows.length})`,
+    handleClick: this.handleViewAllResponsesClick,
+    variant: 'primary',
+  })
+
   render() {
     // hide if submissions are not loaded.
     if (this.props.listData.length === 0) {
@@ -80,11 +86,7 @@ export class ListView extends React.Component {
             },
           ]}
           bulkActions={[
-            (selectedFlatRows) => ({
-              buttonText: `View selected responses (${selectedFlatRows.length})`,
-              handleClick: this.handleViewAllResponsesClick,
-              variant: 'primary',
-            }),
+            this.selectedBulkAction,
           ]}
           columns={[
             {

--- a/src/containers/ListView/index.jsx
+++ b/src/containers/ListView/index.jsx
@@ -34,6 +34,7 @@ export class ListView extends React.Component {
     super(props);
     this.props.initializeApp();
     this.handleViewAllResponsesClick = this.handleViewAllResponsesClick.bind(this);
+    this.selectedBulkAction = this.selectedBulkAction.bind(this);
   }
 
   formatDate = ({ value }) => {
@@ -53,11 +54,13 @@ export class ListView extends React.Component {
     this.props.loadSelectionForReview(rows.map(getSubmissionId));
   }
 
-  selectedBulkAction = (selectedFlatRows) => ({
-    buttonText: `View selected responses (${selectedFlatRows.length})`,
-    handleClick: this.handleViewAllResponsesClick,
-    variant: 'primary',
-  })
+  selectedBulkAction(selectedFlatRows) {
+    return {
+      buttonText: `View selected responses (${selectedFlatRows.length})`,
+      handleClick: this.handleViewAllResponsesClick,
+      variant: 'primary',
+    }
+  }
 
   render() {
     // hide if submissions are not loaded.

--- a/src/containers/ListView/index.jsx
+++ b/src/containers/ListView/index.jsx
@@ -80,11 +80,11 @@ export class ListView extends React.Component {
             },
           ]}
           bulkActions={[
-            {
-              buttonText: 'View selected responses',
+            (selectedFlatRows) => ({
+              buttonText: `View selected responses (${selectedFlatRows.length})`,
               handleClick: this.handleViewAllResponsesClick,
               variant: 'primary',
-            },
+            }),
           ]}
           columns={[
             {


### PR DESCRIPTION
- show the amount of selected response on bulk action

**NOTE**: this is a rebase after [rubric hook](https://github.com/edx/frontend-app-ora-grading/pull/3/files) because I don't want to deal with conflict on updating paragon package.

![image](https://user-images.githubusercontent.com/83240113/135507551-011ab7e3-0845-40cb-970d-d70989beb010.png)
