### PR TITLE
chore: update dev port number

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 NODE_ENV='development'
-PORT=8181
-BASE_URL='localhost:8181'
+PORT=1993
+BASE_URL='localhost:1993'
 LMS_BASE_URL='http://localhost:18000'
 LOGIN_URL='http://localhost:18000/login'
 LOGOUT_URL='http://localhost:18000/logout'

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,6 @@
 NODE_ENV='test'
-PORT=8181
-BASE_URL='localhost:8181'
+PORT=1993
+BASE_URL='localhost:1993'
 LMS_BASE_URL='http://localhost:18000'
 LOGIN_URL='http://localhost:18000/login'
 LOGOUT_URL='http://localhost:18000/logout'


### PR DESCRIPTION
It was an unanimous decision to move port to 1993.

Ticket: [AU-321](https://openedx.atlassian.net/browse/AU-321)
Related PR: [devstack](https://github.com/edx/devstack/pull/841)

### Test

- [x] `npm run start` should run on `localhost:1993`