### PR TITLE
feat: Integration testing - round 1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.snap linguist-generated=false

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -15,6 +15,7 @@ export const ConfirmModal = ({
   <AlertModal
     className="confirm-modal"
     title={title}
+    onClose={() => ({})}
     isOpen={isOpen}
     footerNode={(
       <ActionRow>

--- a/src/components/InfoPopover.jsx
+++ b/src/components/InfoPopover.jsx
@@ -29,6 +29,7 @@ export const InfoPopover = ({ children }) => (
       src={InfoOutline}
       alt="criterion info"
       iconAs={Icon}
+      onClick={() => {}}
     />
   </OverlayTrigger>
 );

--- a/src/components/__snapshots__/ConfirmModal.test.jsx.snap
+++ b/src/components/__snapshots__/ConfirmModal.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`ConfirmModal snapshot: closed 1`] = `
     </ActionRow>
   }
   isOpen={false}
+  onClose={[Function]}
   title="test-title"
 >
   <p>
@@ -48,6 +49,7 @@ exports[`ConfirmModal snapshot: open 1`] = `
     </ActionRow>
   }
   isOpen={true}
+  onClose={[Function]}
   title="test-title"
 >
   <p>

--- a/src/components/__snapshots__/InfoPopover.test.jsx.snap
+++ b/src/components/__snapshots__/InfoPopover.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`Info Popover Component snapshot 1`] = `
     alt="criterion info"
     className="criteria-help-icon"
     iconAs={[MockFunction Icon]}
+    onClick={[Function]}
     src={[MockFunction icons.InfoOutline]}
   />
 </OverlayTrigger>

--- a/src/containers/ListView/ListViewBreadcrumb.jsx
+++ b/src/containers/ListView/ListViewBreadcrumb.jsx
@@ -15,7 +15,7 @@ import urls from 'data/services/lms/urls';
 export const ListViewBreadcrumb = ({ courseId, oraName }) => (
   <>
     <Hyperlink className="py-4" destination={urls.openResponse(courseId)}>
-      <ArrowBack className="mr-3" />
+      <Icon icon={ArrowBack} className="mr-3" />
       Back to all open responses
     </Hyperlink>
     <p className="h3 py-4">

--- a/src/containers/ListView/ListViewBreadcrumb.jsx
+++ b/src/containers/ListView/ListViewBreadcrumb.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { ArrowBack } from '@edx/paragon/icons';
-import { Hyperlink } from '@edx/paragon';
+import { ArrowBack, Launch } from '@edx/paragon/icons';
+import { Hyperlink, Icon } from '@edx/paragon';
 
 import selectors from 'data/selectors';
 import { locationId } from 'data/constants/app';
@@ -20,7 +20,9 @@ export const ListViewBreadcrumb = ({ courseId, oraName }) => (
     </Hyperlink>
     <p className="h3 py-4">
       {oraName}
-      <Hyperlink destination={urls.ora(courseId, locationId)} target="_blank" />
+      <Hyperlink destination={urls.ora(courseId, locationId)} target="_blank">
+        <Icon icon={Launch} />
+      </Hyperlink>
     </p>
   </>
 );

--- a/src/containers/ListView/ListViewBreadcrumb.test.jsx
+++ b/src/containers/ListView/ListViewBreadcrumb.test.jsx
@@ -16,6 +16,7 @@ import {
 
 jest.mock('@edx/paragon', () => ({
   Hyperlink: () => 'Hyperlink',
+  Icon: () => 'Icon',
 }));
 
 jest.mock('data/selectors', () => ({

--- a/src/containers/ListView/ListViewBreadcrumb.test.jsx
+++ b/src/containers/ListView/ListViewBreadcrumb.test.jsx
@@ -18,6 +18,10 @@ jest.mock('@edx/paragon', () => ({
   Hyperlink: () => 'Hyperlink',
   Icon: () => 'Icon',
 }));
+jest.mock('@edx/paragon/icons', () => ({
+  ArrowBack: 'icons.ArrowBack',
+  Launch: 'icons.Launch',
+}));
 
 jest.mock('data/selectors', () => ({
   __esModule: true,

--- a/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
+++ b/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
@@ -6,8 +6,9 @@ exports[`ListViewBreadcrumb component component snapshot: empty (no list data) 1
     className="py-4"
     destination="openResponseUrl(test-course-id)"
   >
-    <icons.ArrowBack
+    <Icon
       className="mr-3"
+      icon="icons.ArrowBack"
     />
     Back to all open responses
   </Hyperlink>

--- a/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
+++ b/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
@@ -18,7 +18,11 @@ exports[`ListViewBreadcrumb component component snapshot: empty (no list data) 1
     <Hyperlink
       destination="oraUrl(test-course-id, fake-location-id)"
       target="_blank"
-    />
+    >
+      <Icon
+        icon={[Function]}
+      />
+    </Hyperlink>
   </p>
 </Fragment>
 `;

--- a/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
+++ b/src/containers/ListView/__snapshots__/ListViewBreadcrumb.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`ListViewBreadcrumb component component snapshot: empty (no list data) 1
     className="py-4"
     destination="openResponseUrl(test-course-id)"
   >
-    <SvgArrowBack
+    <icons.ArrowBack
       className="mr-3"
     />
     Back to all open responses
@@ -20,7 +20,7 @@ exports[`ListViewBreadcrumb component component snapshot: empty (no list data) 1
       target="_blank"
     >
       <Icon
-        icon={[Function]}
+        icon="icons.Launch"
       />
     </Hyperlink>
   </p>

--- a/src/containers/ListView/__snapshots__/index.test.jsx.snap
+++ b/src/containers/ListView/__snapshots__/index.test.jsx.snap
@@ -110,6 +110,7 @@ exports[`ListView component component render tests snapshots snapshot: happy pat
       Array [
         Object {
           "buttonText": "View all responses",
+          "className": "view-all-responses-btn",
           "handleClick": [MockFunction this.handleViewAllResponsesClick],
           "variant": "primary",
         },

--- a/src/containers/ListView/index.jsx
+++ b/src/containers/ListView/index.jsx
@@ -58,6 +58,7 @@ export class ListView extends React.Component {
   selectedBulkAction(selectedFlatRows) {
     return {
       buttonText: `View selected responses (${selectedFlatRows.length})`,
+      className: 'view-selected-responses-btn',
       handleClick: this.handleViewAllResponsesClick,
       variant: 'primary',
     };
@@ -86,6 +87,7 @@ export class ListView extends React.Component {
             {
               buttonText: 'View all responses',
               handleClick: this.handleViewAllResponsesClick,
+              className: 'view-all-responses-btn',
               variant: 'primary',
             },
           ]}

--- a/src/data/reducers/grading.js
+++ b/src/data/reducers/grading.js
@@ -100,7 +100,7 @@ const app = createReducer(initialState, {
   [actions.grading.preloadPrev]: (state, { payload }) => ({ ...state, prev: payload }),
   [actions.grading.loadNext]: (state, { payload }) => ({
     ...state,
-    prev: state.current,
+    prev: { response: state.current.response },
     current: { response: state.next.response, ...payload },
     activeIndex: state.activeIndex + 1,
     gradeData: {
@@ -111,7 +111,7 @@ const app = createReducer(initialState, {
   }),
   [actions.grading.loadPrev]: (state, { payload }) => ({
     ...state,
-    next: state.current,
+    next: { response: state.current.response },
     current: { response: state.prev.response, ...payload },
     gradeData: {
       ...state.gradeData,

--- a/src/data/thunkActions/grading.js
+++ b/src/data/thunkActions/grading.js
@@ -140,7 +140,21 @@ export const startGrading = () => (dispatch, getState) => {
 };
 
 /**
- * Stops the grading process for the current submisison
+ * Cancels the grading process for the current submisison.
+ * Releases the lock and dispatches stopGrading on success.
+ */
+export const cancelGrading = () => (dispatch, getState) => {
+  dispatch(requests.setLock({
+    value: false,
+    submissionId: selectors.grading.selected.submissionId(getState()),
+    onSuccess: () => {
+      dispatch(module.stopGrading());
+    },
+  }));
+};
+
+/**
+ * Stops the grading process for the current submission (local only)
  * Clears the local grade data for the current submission and sets grading state
  * to False
  */
@@ -154,5 +168,6 @@ export default StrictDict({
   loadNext,
   loadPrev,
   startGrading,
+  cancelGrading,
   stopGrading,
 });

--- a/src/data/thunkActions/grading.test.js
+++ b/src/data/thunkActions/grading.test.js
@@ -313,9 +313,38 @@ describe('grading thunkActions', () => {
     });
   });
 
+  describe('cancelGrading', () => {
+    let stopGrading;
+    beforeAll(() => {
+      stopGrading = thunkActions.stopGrading;
+      thunkActions.stopGrading = () => 'stop grading';
+    });
+    beforeEach(() => {
+      getDispatched(thunkActions.cancelGrading());
+      actionArgs = dispatched.setLock;
+    });
+    afterAll(() => {
+      thunkActions.stopGrading = stopGrading;
+    });
+    test('dispatches setLock with selected submissionId and value: false', () => {
+      expect(actionArgs).not.toEqual(undefined);
+      expect(actionArgs.value).toEqual(false);
+      expect(actionArgs.submissionId).toEqual(selectors.grading.selected.submissionId(testState));
+    });
+    describe('onSuccess', () => {
+      beforeEach(() => {
+        dispatch.mockClear();
+      });
+      test('dispatches stopGrading thunkAction', () => {
+        actionArgs.onSuccess();
+        expect(dispatch.mock.calls).toContainEqual([thunkActions.stopGrading()]);
+      });
+    });
+  });
+
   describe('stopGrading', () => {
     it('dispatches grading.clearGrade and app.setGrading(false)', () => {
-      thunkActions.stopGrading()(dispatch);
+      thunkActions.stopGrading()(dispatch, getState);
       expect(dispatch.mock.calls).toEqual([
         [actions.grading.clearGrade()],
         [actions.app.setGrading(false)],

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -1,0 +1,7 @@
+export const mockSuccess = (returnValFn) => (...args) => (
+  new Promise((resolve) => resolve(returnValFn(...args)))
+);
+
+export const mockFailure = (returnValFn) => (...args) => (
+  new Promise((resolve, reject) => reject(returnValFn(...args)))
+);


### PR DESCRIPTION
Resolves a number of console warnings about paragon component usage, and introduces a set of integration tests that go through initialization, selection, and submission navigation.  The tests verify against redux shape that the submissions are loaded into the list appropriately, selected for review appropriately, and that as you navigate through selected submissions, the "current" has the full status and response, and prev/next containers just hold the response.