### PR TITLE
feat: don't show file table when file upload response config disabled

### DIFF
--- a/src/containers/ResponseDisplay/__snapshots__/index.test.jsx.snap
+++ b/src/containers/ResponseDisplay/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResponseDisplay component snapshot no response 1`] = `
+exports[`ResponseDisplay component snapshot file upload disable with valid response 1`] = `
+<div
+  className="response-display"
+>
+  <Card>
+    <Card.Body>
+      parsed html (sanitized (some text response here))
+    </Card.Body>
+  </Card>
+</div>
+`;
+
+exports[`ResponseDisplay component snapshot file upload disabled without response 1`] = `
 <div
   className="response-display"
 >
@@ -15,7 +27,7 @@ exports[`ResponseDisplay component snapshot no response 1`] = `
 </div>
 `;
 
-exports[`ResponseDisplay component snapshot with valid response 1`] = `
+exports[`ResponseDisplay component snapshot file upload enable with valid response 1`] = `
 <div
   className="response-display"
 >
@@ -38,6 +50,21 @@ exports[`ResponseDisplay component snapshot with valid response 1`] = `
   <Card>
     <Card.Body>
       parsed html (sanitized (some text response here))
+    </Card.Body>
+  </Card>
+</div>
+`;
+
+exports[`ResponseDisplay component snapshot file upload enable without response 1`] = `
+<div
+  className="response-display"
+>
+  <SubmissionFiles
+    files={Array []}
+  />
+  <Card>
+    <Card.Body>
+      parsed html (sanitized ())
     </Card.Body>
   </Card>
 </div>

--- a/src/containers/ResponseDisplay/index.jsx
+++ b/src/containers/ResponseDisplay/index.jsx
@@ -9,6 +9,7 @@ import createDOMPurify from 'dompurify';
 import parse from 'html-react-parser';
 
 import selectors from 'data/selectors';
+import { fileUploadResponseOptions } from 'data/services/lms/constants';
 
 import SubmissionFiles from './SubmissionFiles';
 
@@ -31,10 +32,16 @@ export class ResponseDisplay extends React.Component {
     return this.props.response.files;
   }
 
+  get allowFileUpload() {
+    return (
+      this.props.fileUploadResponseConfig !== fileUploadResponseOptions.none
+    );
+  }
+
   render() {
     return (
       <div className="response-display">
-        <SubmissionFiles files={this.submittedFiles} />
+        {this.allowFileUpload && <SubmissionFiles files={this.submittedFiles} />}
         <Card>
           <Card.Body>{this.textContent}</Card.Body>
         </Card>
@@ -48,6 +55,7 @@ ResponseDisplay.defaultProps = {
     text: '',
     files: [],
   },
+  fileUploadResponseConfig: fileUploadResponseOptions.none,
 };
 ResponseDisplay.propTypes = {
   response: PropTypes.shape({
@@ -58,10 +66,14 @@ ResponseDisplay.propTypes = {
       }),
     ).isRequired,
   }),
+  fileUploadResponseConfig: PropTypes.oneOf(
+    Object.values(fileUploadResponseOptions),
+  ),
 };
 
 export const mapStateToProps = (state) => ({
   response: selectors.grading.selected.response(state),
+  fileUploadResponseConfig: selectors.app.ora.fileUploadResponseConfig(state),
 });
 
 export const mapDispatchToProps = {};

--- a/src/containers/ResponseDisplay/index.test.jsx
+++ b/src/containers/ResponseDisplay/index.test.jsx
@@ -5,6 +5,7 @@ import createDOMPurify from 'dompurify';
 import parse from 'html-react-parser';
 
 import selectors from 'data/selectors';
+import { fileUploadResponseOptions } from 'data/services/lms/constants';
 
 import { ResponseDisplay, mapStateToProps } from '.';
 
@@ -22,6 +23,11 @@ jest.mock('data/selectors', () => ({
     grading: {
       selected: {
         response: (state) => ({ response: state }),
+      },
+    },
+    app: {
+      ora: {
+        fileUploadResponseConfig: (state) => ({ config: state }),
       },
     },
   },
@@ -50,19 +56,43 @@ describe('ResponseDisplay', () => {
           },
         ],
       },
+      fileUploadResponseConfig: 'optional',
     };
     let el;
     beforeAll(() => {
       global.window = {};
-      el = shallow(<ResponseDisplay />);
     });
-
+    beforeEach(() => {
+      el = shallow(<ResponseDisplay {...props} />);
+    });
     describe('snapshot', () => {
-      test('no response', () => {
+      test('file upload enable with valid response', () => {
         expect(el).toMatchSnapshot();
       });
-      test('with valid response', () => {
-        el.setProps({ ...props });
+
+      test('file upload enable without response', () => {
+        el.setProps({
+          response: {
+            text: '',
+            files: [],
+          },
+        });
+        expect(el).toMatchSnapshot();
+      });
+      test('file upload disable with valid response', () => {
+        el.setProps({
+          fileUploadResponseConfig: fileUploadResponseOptions.none,
+        });
+        expect(el).toMatchSnapshot();
+      });
+
+      test('file upload disabled without response', () => {
+        el.setProps({
+          response: {
+            text: '',
+            files: [],
+          },
+        });
         expect(el).toMatchSnapshot();
       });
     });
@@ -75,6 +105,11 @@ describe('ResponseDisplay', () => {
 
       test('get submittedFiles', () => {
         expect(el.instance().submittedFiles).toEqual(props.response.files);
+      });
+      test('get allowFileUpload', () => {
+        expect(el.instance().allowFileUpload).toEqual(
+          props.fileUploadResponseConfig !== fileUploadResponseOptions.none,
+        );
       });
     });
   });
@@ -90,6 +125,11 @@ describe('ResponseDisplay', () => {
     test('response loads from grading.selected.response', () => {
       expect(mapped.response).toEqual(
         selectors.grading.selected.response(testState),
+      );
+    });
+    test('response loads from grading.selected.response', () => {
+      expect(mapped.fileUploadResponseConfig).toEqual(
+        selectors.app.ora.fileUploadResponseConfig(testState),
       );
     });
   });

--- a/src/data/reducers/app.js
+++ b/src/data/reducers/app.js
@@ -8,6 +8,7 @@ const initialState = {
     name: '',
     type: '',
     rubricConfig: null,
+    fileUploadResponseConfig: null,
   },
   courseMetadata: {
     name: '',

--- a/src/data/selectors/app.js
+++ b/src/data/selectors/app.js
@@ -41,6 +41,11 @@ export const ora = {
    * @return {string} - ORA type (team vs individual)
    */
   type: oraMetadataSelector(data => data.type),
+  /**
+   * Return file load response config
+   * @returns {string} - file load response config
+   */
+  fileUploadResponseConfig: oraMetadataSelector(data => data.fileUploadResponseConfig),
 };
 
 /**

--- a/src/data/selectors/app.test.js
+++ b/src/data/selectors/app.test.js
@@ -104,6 +104,9 @@ describe('app selectors unit tests', () => {
     test('ora.type selector returns type from oraMetadata', () => {
       testOraSelector(selectors.ora.type, oraMetadata.type);
     });
+    test('ora.fileUploadResponseConfig selector returns file upload config from oraMetadata', () => {
+      testOraSelector(selectors.ora.fileUploadResponseConfig, oraMetadata.fileUploadResponseConfig);
+    });
     test('rubricConfig selector returns rubricConfig from oraMetadata', () => {
       testOraSelector(selectors.rubric.config, oraMetadata.rubricConfig);
     });

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -22,7 +22,7 @@ const mockFailure = (returnValFn) => (...args) => (
 /**
  * get('/api/initialize', { ora_location, course_id? })
  * @return {
- *   oraMetadata: { name, prompt, type ('individual' vs 'team')  },
+ *   oraMetadata: { name, prompt, type ('individual' vs 'team'), rubricConfig, fileUploadResponseConfig },
  *   courseMetadata: { courseOrg, courseName, courseNumber, courseId },
  *   submissions: {
  *     [submissionId]: {

--- a/src/data/services/lms/constants.js
+++ b/src/data/services/lms/constants.js
@@ -23,3 +23,9 @@ export const feedbackRequirement = StrictDict({
   required: 'required',
   optional: 'optional',
 });
+
+export const fileUploadResponseOptions = StrictDict({
+  required: 'required',
+  optional: 'optional',
+  none: 'none',
+});

--- a/src/data/services/lms/fakeData/ora.js
+++ b/src/data/services/lms/fakeData/ora.js
@@ -57,9 +57,12 @@ const rubricConfig = {
   ],
 };
 
+const fileUploadResponseConfig = 'optional';
+
 export default {
   name,
   prompt,
   rubricConfig,
   type,
+  fileUploadResponseConfig,
 };


### PR DESCRIPTION
Test Instructions:
- set [fileUploadResponseConfig](https://github.com/edx/frontend-app-ora-grading/pull/25/files#diff-97adda5093beaf202b4a80a411a19b9d258438b91a56bbefc7fb587377e4768cR59) to 'none' for disabling
- set it to 'required' or 'optional' to enable.

<img width="1668" alt="Screen Shot 2021-11-02 at 3 57 13 PM" src="https://user-images.githubusercontent.com/83240113/139943387-717be8ee-510e-47f0-881a-3a8520047806.png">
<img width="1670" alt="Screen Shot 2021-11-02 at 3 58 30 PM" src="https://user-images.githubusercontent.com/83240113/139943388-a883d586-baa0-4899-9df6-4b268079393e.png">
