### PR TITLE
fix: grade data is empty object when there isn't grade data

### DIFF
--- a/src/data/redux/grading/selectors.js
+++ b/src/data/redux/grading/selectors.js
@@ -136,13 +136,13 @@ selected.userDisplay = createSelector(
  ***********************************/
 
 /**
- * Returns the grade data for the selected submission
+ * Returns the grade data for the selected submission or empty object
  * @return {obj} grade data
  *  { score, overallFeedback, criteria }
  */
 selected.gradeData = createSelector(
   [module.selected.submissionUUID, module.simpleSelectors.gradeData],
-  (submissionUUID, gradeData) => gradeData[submissionUUID],
+  (submissionUUID, gradeData) => gradeData[submissionUUID] || {},
 );
 
 /**

--- a/src/data/redux/thunkActions/grading.js
+++ b/src/data/redux/thunkActions/grading.js
@@ -50,7 +50,7 @@ export const loadSubmission = () => (dispatch, getState) => {
       if (selectors.grading.selected.isGrading(getState())) {
         dispatch(actions.app.setShowRubric(true));
         let gradeData = selectors.grading.selected.gradeData(getState());
-        if (!gradeData) {
+        if (!Object.keys(gradeData).length) {
           gradeData = selectors.app.emptyGrade(getState());
         }
         const lockStatus = selectors.grading.selected.lockStatus(getState());
@@ -75,7 +75,7 @@ export const startGrading = () => (dispatch, getState) => {
     onSuccess: (response) => {
       dispatch(actions.app.setShowRubric(true));
       let gradeData = selectors.grading.selected.gradeData(getState());
-      if (!gradeData) {
+      if (!Object.keys(gradeData).length) {
         gradeData = selectors.app.emptyGrade(getState());
       }
       dispatch(actions.grading.startGrading({ ...response, gradeData }));

--- a/src/data/redux/thunkActions/grading.test.js
+++ b/src/data/redux/thunkActions/grading.test.js
@@ -156,8 +156,8 @@ describe('grading thunkActions', () => {
         const expected = [
           actions.grading.startGrading({ ...startResponse, gradeData: emptyGrade }),
         ];
-        selectors.grading.selected.gradeData.mockReturnValue(undefined);
-        actionArgs.onSuccess({ ...startResponse, gradeData: undefined });
+        selectors.grading.selected.gradeData.mockReturnValue({});
+        actionArgs.onSuccess({ ...startResponse, gradeData: {} });
         expect(dispatch.mock.calls).toContainEqual(expected);
         expect(dispatch.mock.calls).toContainEqual([actions.app.setShowRubric(true)]);
         dispatch.mockClear();


### PR DESCRIPTION
Description: 
On start grading, the gradeData is empty. The backend is sending back empty object. We were expecting null.

TLDR; make gradeData work with empty object instead of just null.