### PR TITLE
fix: update setup test to mock locationId

### DIFF
--- a/src/containers/ListView/ListViewBreadcrumb.test.jsx
+++ b/src/containers/ListView/ListViewBreadcrumb.test.jsx
@@ -23,9 +23,6 @@ jest.mock('data/redux', () => ({
   },
 }));
 
-jest.mock('data/constants/app', () => ({
-  locationId: 'fake-location-id',
-}));
 jest.mock('data/services/lms/urls', () => ({
   openResponse: (courseId) => `openResponseUrl(${courseId})`,
   ora: (courseId, locationId) => `oraUrl(${courseId}, ${locationId})`,

--- a/src/data/redux/thunkActions/app.test.js
+++ b/src/data/redux/thunkActions/app.test.js
@@ -6,9 +6,6 @@ import thunkActions from './app';
 jest.mock('./requests', () => ({
   initializeApp: (args) => ({ initializeApp: args }),
 }));
-jest.mock('data/constants/app', () => ({
-  locationId: 'fake-location-id',
-}));
 
 describe('app thunkActions', () => {
   let dispatch;

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -95,3 +95,7 @@ jest.mock('@edx/paragon/icons', () => ({
   InfoOutline: jest.fn().mockName('icons.InfoOutline'),
   Launch: jest.fn().mockName('icons.Launch'),
 }));
+
+jest.mock('data/constants/app', () => ({
+  locationId: 'fake-location-id',
+}));


### PR DESCRIPTION
Some individual test couldn't be run because the use of constant the require mock from window. This would help lessen the confusion.

This is to fix `npx jest some_file` doesn't work