### PR TITLE
chore: update brand config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ public/samples/
 .idea
 .vscode
 
+# Local package dependencies
+module.config.js
+
 ### transifex ###
 src/i18n/transifex_input.json
 temp

--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,7 +1,7 @@
 /* I'm here to allow autoprefixing in webpack.prod.config.js */
 module.exports = {
   plugins: [
-    require('autoprefixer')({ grid: true, browsers: ['>1%'] }),
+    require('autoprefixer')({ grid: 'autoplace', overrideBrowserslist: ['>1%'] }),
   ],
 };
 


### PR DESCRIPTION
[Related PR](https://github.com/edx/edx-internal/pull/6316)

Test Instruction:
- stop local docker instance with `make dev.down.frontend-app-learning` in devstack
- create file `module.config.js` in root dir
```js
module.exports = {
    /*
    Modules you want to use from local source code.  Adding a module here means that when this app
    runs its build, it'll resolve the source from peer directories of this app.
    moduleName: the name you use to import code from the module.
    dir: The relative path to the module's source code.
    dist: The sub-directory of the source code where it puts its build artifact.  Often "dist".
    */
    localModules: [
      { moduleName: '@edx/brand', dir: '../brand-edx.org' },
      { moduleName: '@edx/paragon/icons', dir: '../paragon/icons', dist: '' },
      { moduleName: '@edx/paragon/scss/core', dir: '../paragon', dist: 'scss/core' },
      { moduleName: '@edx/paragon', dir: '../paragon', dist: 'dist' },
    ],
  };
```
- go back to work space and clone
```bash
git clone https://github.com/edx/paragon.git
git clone https://github.com/edx/brand-edx.org.git
```
- checkout paragon on `16.4.4` which is match with the current version install.
```
cd paragon
git checkout 4e13370ba2bfa3aa0db5a322b471175212805acb
npm install && npm run build
```
- start ora-grading
```
cd ../frontend-app-ora-grading
npm install && npm start
```

This is just to prove the app is using local installation. You should see `autoprefix` warning, which essentially telling about the IE lack of support of grid-template. [To learn more](https://github.com/postcss/autoprefixer/blob/main/README.md#grid-autoplacement-support-in-ie)

