### PR TITLE
chore: update integration tests

### DIFF
--- a/src/test/inspector.js
+++ b/src/test/inspector.js
@@ -32,7 +32,7 @@ class Inspector {
     return {
       table,
       tableRows,
-      selectedBtn: () => this.getByText('View selected responses (5)'),
+      selectedBtn: (num) => this.getByText(`View selected responses (${num})`),
       loadingResponses: () => this.getByText(appMessages.ListView.loadingResponses),
       listCheckbox: (index) => (
         within(tableRows().item(index)).getByTitle('Toggle Row Selected')
@@ -100,6 +100,7 @@ class Inspector {
         ),
         loadErrorHeading: () => this.findByText(appMessages.ReviewErrors.loadErrorHeading),
         startGradingBtn: () => this.findByText(appMessages.ReviewActionsComponents.startGrading),
+        overrideGradeBtn: () => this.findByText(appMessages.ReviewActionsComponents.overrideGrade),
         submitGradeBtn: () => this.findByText(appMessages.Rubric.submitGrade),
       },
     };

--- a/src/utils/StrictDict.js
+++ b/src/utils/StrictDict.js
@@ -4,6 +4,10 @@ const strictGet = (target, name) => {
     return target;
   }
 
+  if (name === '$$typeof') {
+    return typeof target;
+  }
+
   if (name in target || name === '_reactFragment') {
     return target[name];
   }

--- a/src/utils/StrictDict.test.js
+++ b/src/utils/StrictDict.test.js
@@ -44,6 +44,7 @@ describe('StrictDict', () => {
   });
   it('allows type querying', () => {
     expect(typeof dict).toEqual('object');
+    expect(dict.$$typeof).toEqual('object');
   });
   it('allows entry listing', () => {
     expect(Object.entries(dict)).toEqual(Object.entries(rawDict));


### PR DESCRIPTION
Update the integration tests to go through grading as well as covering maintaining grade state between navigation.

Note: this only covers workflow of unlocked, ungraded submissions.