### PR TITLE
fix: locationId should strip PUBLIC_PATH prefix

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 
-export const routePath = `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = window.location.pathname.slice(1);
+export const getRoutePath = () => `${getConfig().PUBLIC_PATH}:courseId`;
+export const routePath = getRoutePath();
+
+export const getLocationId = () => window.location.pathname.replace(new RegExp(`^${getConfig().PUBLIC_PATH}`), '');
+export const locationId = getLocationId();

--- a/src/data/constants/app.test.js
+++ b/src/data/constants/app.test.js
@@ -4,7 +4,7 @@ import * as constants from './app';
 jest.unmock('./app');
 
 jest.mock('@edx/frontend-platform', () => {
-  const PUBLIC_PATH = 'test-public-path';
+  const PUBLIC_PATH = '/test-public-path/';
   return {
     getConfig: () => ({ PUBLIC_PATH }),
     PUBLIC_PATH,
@@ -13,12 +13,14 @@ jest.mock('@edx/frontend-platform', () => {
 
 describe('app constants', () => {
   test('route path draws from public path and adds courseId', () => {
-    expect(constants.routePath).toEqual(`${platform.PUBLIC_PATH}:courseId`);
+    expect(constants.getRoutePath()).toEqual(`${platform.PUBLIC_PATH}:courseId`);
   });
   test('locationId returns trimmed pathname', () => {
+    const path = 'somepath.jpg';
     const old = window.location;
-    window.location = { pathName: '/somePath.jpg' };
-    expect(constants.locationId).toEqual(window.location.pathname.slice(1));
+    delete window.location;
+    window.location = new URL(`http://foo.bar${platform.PUBLIC_PATH}${path}`);
+    expect(constants.getLocationId()).toEqual(path);
     window.location = old;
   });
 });

--- a/src/data/services/lms/api.test.js
+++ b/src/data/services/lms/api.test.js
@@ -12,10 +12,6 @@ jest.mock('./utils', () => ({
   stringifyUrl: args => ({ stringifyUrl: args }),
 }));
 
-jest.mock('data/constants/app', () => ({
-  locationId: 'test-location-id',
-}));
-
 const gradeData = 'test-grade-data';
 const submissionUUID = 'test-submission-uuid';
 const submissionUUIDs = ['some', 'submission', 'uuid'];


### PR DESCRIPTION
If `PUBLIC_PATH` were set to anything other than the default '/', and the MFE were actually hosted under that path as intended, `locationId` would be initialized to the wrong value.