### PR TITLE
fix: BadOraLocationResponse error

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,4 @@
 import { getConfig } from '@edx/frontend-platform';
 
 export const routePath = `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = window.location.pathname.slice(1);
+export const locationId = window.location.pathname.replace(getConfig().PUBLIC_PATH, '');

--- a/src/data/constants/app.test.js
+++ b/src/data/constants/app.test.js
@@ -4,7 +4,7 @@ import * as constants from './app';
 jest.unmock('./app');
 
 jest.mock('@edx/frontend-platform', () => {
-  const PUBLIC_PATH = 'test-public-path';
+  const PUBLIC_PATH = '/test-public-path/';
   return {
     getConfig: () => ({ PUBLIC_PATH }),
     PUBLIC_PATH,
@@ -17,8 +17,8 @@ describe('app constants', () => {
   });
   test('locationId returns trimmed pathname', () => {
     const old = window.location;
-    window.location = { pathName: '/somePath.jpg' };
-    expect(constants.locationId).toEqual(window.location.pathname.slice(1));
+    window.location = { pathName: `${platform.PUBLIC_PATH}somePath.jpg` };
+    expect(constants.locationId).toEqual(window.location.pathname.replace(platform.PUBLIC_PATH, ''));
     window.location = old;
   });
 });


### PR DESCRIPTION
Refactor the locationId constant for subdirectory-based deployments.

Exclude the MFE's `PUBLIC_PATH` from the constant.

The `window.location.pathname` example:
```
<PUBLIC_PATH>block-v1:oragrading+oragrading+oragrading+type@openassessment+block@ee217e897a954c1faa3b29317da0f2e7
```
Where the `PUBLIC_PATH` could be:
- `'/'` - for subdomain-based deployments (default)
- `'/mfe-specifix-public-path/'` - for subdirectory-based deployments

Note:
- this is a backport from [master](https://github.com/openedx/frontend-app-ora-grading/pull/167)