### PR TITLE
fix: location id error

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,4 @@
 import { getConfig } from '@edx/frontend-platform';
 
 export const routePath = () => `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = () => window.location.pathname.replace(getConfig().PUBLIC_PATH, '');
+export const locationId = () => decodeURIComponent(window.location.pathname).replace(getConfig().PUBLIC_PATH, '');


### PR DESCRIPTION
The current code is wrong for this case (localtion id contains characters like: **Đ**) :
https://apps.demo.openedx.overhang.io/ora-grading/block-v1:ORG+Đ001+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f

Current code:
```
window.location.pathname.replace(getConfig().PUBLIC_PATH, '') = 
block-v1:ORG+%C4%90+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f
```

This PR code
```
decodeURIComponent(window.location.pathname).replace('/ora-grading/', '') =
block-v1:ORG+Đ+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f
```

The localtionId is used in [initialize request](https://github.com/openedx/frontend-app-ora-grading/blob/master/src/data/services/lms/api.js)
{LMS_BASE_URL}/api/ora_staff_grader/initialize?oraLocation={locationId}