### PR TITLE
fix: when there is no options, the validation should be valid

### DIFF
--- a/src/data/redux/grading/selectors/validation.js
+++ b/src/data/redux/grading/selectors/validation.js
@@ -32,7 +32,7 @@ validation.criteria = createSelector(
       criterion.feedback === feedbackRequirement.required
       && gradingData.criteria[index].feedback === ''
     ),
-    selectedOption: gradingData.criteria[index].selectedOption !== '',
+    selectedOption: rubricConfig.criteria[index].options.length === 0 || gradingData.criteria[index].selectedOption !== '',
   })),
 );
 

--- a/src/data/redux/grading/selectors/validation.test.js
+++ b/src/data/redux/grading/selectors/validation.test.js
@@ -64,8 +64,8 @@ describe('validation grading selectors unit tests', () => {
       expect(preSelectors).toEqual([selected.gradingData, appSelectors.rubric.config]);
     });
     describe('returned object', () => {
-      const feedbackOptional = { feedback: feedbackRequirement.optional };
-      const feedbackRequired = { feedback: feedbackRequirement.required };
+      const feedbackOptional = { feedback: feedbackRequirement.optional, options: [1] };
+      const feedbackRequired = { feedback: feedbackRequirement.required, options: [1] };
       describe('feedback', () => {
         const validFeedback = { feedback: 'Fair' };
         const emptyFeedback = { feedback: '' };
@@ -84,6 +84,14 @@ describe('validation grading selectors unit tests', () => {
             { criteria: [feedbackOptional, feedbackOptional] },
           );
           expect(output.map(({ selectedOption }) => selectedOption)).toEqual([true, false]);
+        });
+        it('returns true criteria options are empty', () => {
+          const emptyOptionsFeedback = { ...feedbackOptional, options: [] };
+          const output = cb(
+            { criteria: [{ selectedOption: '' }, { selectedOption: 'Invalid' }] },
+            { criteria: [emptyOptionsFeedback, emptyOptionsFeedback] },
+          );
+          expect(output.map(({ selectedOption }) => selectedOption)).toEqual([true, true]);
         });
       });
     });


### PR DESCRIPTION
When rubric config doesn't have criterion options, validate selectedOption should always be valid.

### Steps to reproduce this issue:

1. As an instructor, create an ORA. (Note: I selected "Self assessment to Peer" in my test. Presumably this issue will be repro-able even if just Staff assessment is selected but noting in case it's something specific to when both assessment steps are enabled.)
2. Click to edit the ORA.
3. Go to the Assessment Steps tab.
4. Check the box next to "Staff assessment".
5. Under Rubric, click on the "X" to delete the first criterion.
6. Click on the "X" next to delete the last criterion's options (Options are where points are specified).
7. Change "Feedback for this criterion" to "Required".
8. Save and publish your changes.
9. As a learner, go to the ORA assignment and submit something so it can be "graded".
10. (If you've got peers enabled to, you'll need to grade some peers now. Otherwise can skip.)
11. As an instructor, go to the ORA assignment and click on "Grade available responses."
12. Get redirected to the Enhanced Staff Grader page.
13. Check the box next to a learner's name. 
14. Click on "View Selected Responses".
15. Click on "Start grading".
16. See the Rubric on the side.
17. Add some comments under "Provide feedback".
18. Add optional comments under "Overall comments".
19. Click "Submit grade".

Ticket: https://2u-internal.atlassian.net/browse/AU-878
Related PR: https://github.com/openedx/edx-platform/pull/32372