### PR TITLE
fix: decodeURIComponent for locationId 

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,4 @@
 import { getConfig } from '@edx/frontend-platform';
 
 export const routePath = () => `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = () => window.location.pathname.replace(getConfig().PUBLIC_PATH, '');
+export const locationId = () => decodeURIComponent(window.location.pathname).replace(getConfig().PUBLIC_PATH, '');

--- a/src/data/constants/app.test.js
+++ b/src/data/constants/app.test.js
@@ -15,10 +15,29 @@ describe('app constants', () => {
   test('route path draws from public path and adds courseId', () => {
     expect(constants.routePath()).toEqual(`${platform.PUBLIC_PATH}:courseId`);
   });
-  test('locationId returns trimmed pathname', () => {
-    const old = window.location;
-    window.location = { pathName: `${platform.PUBLIC_PATH}somePath.jpg` };
-    expect(constants.locationId()).toEqual(window.location.pathname.replace(platform.PUBLIC_PATH, ''));
-    window.location = old;
+  describe('locationId', () => {
+    const domain = 'https://example.com';
+
+    test('returns trimmed pathname', () => {
+      const old = window.location;
+      Object.defineProperty(window, 'location', {
+        value: new URL(`${domain}${platform.PUBLIC_PATH}somePath.jpg`),
+        writable: true,
+      });
+      expect(constants.locationId()).toEqual(window.location.pathname.replace(platform.PUBLIC_PATH, ''));
+      window.location = old;
+    });
+    test('handle none-standard characters pathName', () => {
+      const old = window.location;
+      const noneStandardPath = `${platform.PUBLIC_PATH}ORG+%C4%90+2023`;
+      const expectedPath = `${platform.PUBLIC_PATH}ORG+Đ+2023`;
+      Object.defineProperty(window, 'location', {
+        value: new URL(`${domain}${noneStandardPath}`),
+        writable: true,
+      });
+      expect(noneStandardPath).not.toEqual(expectedPath);
+      expect(constants.locationId()).toEqual(expectedPath.replace(platform.PUBLIC_PATH, ''));
+      window.location = old;
+    });
   });
 });


### PR DESCRIPTION
The current code is wrong for this case (localtion id contains characters like: Đ) :
[https://apps.demo.openedx.overhang.io/ora-grading/block-v1:ORG+Đ001+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f](https://apps.demo.openedx.overhang.io/ora-grading/block-v1:ORG+%C4%90001+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f)

Current code:

```
window.location.pathname.replace(getConfig().PUBLIC_PATH, '') = 
block-v1:ORG+%C4%90+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f
```
This PR code
```
decodeURIComponent(window.location.pathname).replace('/ora-grading/', '') =
block-v1:ORG+Đ+2023+type@openassessment+block@14709d5612014c57befb3c278b3b9b4f
```
The localtionId is used in [initialize request](https://github.com/openedx/frontend-app-ora-grading/blob/master/src/data/services/lms/api.js)
{LMS_BASE_URL}/api/ora_staff_grader/initialize?oraLocation={locationId}