### PR TITLE
chore: update header and footer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
-        "@edx/frontend-component-footer": "^11.7.0",
-        "@edx/frontend-component-header": "^3.7.0",
+        "@edx/frontend-component-footer": "^12.0.0",
+        "@edx/frontend-component-header": "^4.2.2",
         "@edx/frontend-platform": "^4.1.0",
         "@edx/paragon": "^20.30.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -3334,63 +3334,75 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.0.tgz",
-      "integrity": "sha512-TVEoHBhWKpcD/7yn03nyKx0mtEMOLNE3qmptyzaeVRh+CEEEW+FDcPMj4LSf8ZqL8VvRcxzb14Rl3U4Y67gSig==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-12.0.0.tgz",
+      "integrity": "sha512-m8Rx6ZPWzIN5XLrz6Ft3aTuFo0rty0jECd79CBYWdm0D9KD1WxoYEG+fElluyOQp/t42T5jLImHTSWjFURx5kw==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
-        "@fortawesome/fontawesome-svg-core": "6.3.0",
-        "@fortawesome/free-brands-svg-icons": "6.3.0",
-        "@fortawesome/free-regular-svg-icons": "6.3.0",
-        "@fortawesome/free-solid-svg-icons": "6.3.0",
+        "@fortawesome/fontawesome-svg-core": "6.4.0",
+        "@fortawesome/free-brands-svg-icons": "6.4.0",
+        "@fortawesome/free-regular-svg-icons": "6.4.0",
+        "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-fontawesome": "0.2.0"
       },
       "peerDependencies": {
+        "@edx/frontend-platform": "^4.0.0",
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
-      "integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
-      "integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.3.0"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.3.0.tgz",
-      "integrity": "sha512-xI0c+a8xnKItAXCN8rZgCNCJQiVAd2Y7p9e2ND6zN3J3ekneu96qrePieJ7yA7073C1JxxoM3vH1RU7rYsaj8w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.3.0"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz",
-      "integrity": "sha512-x5tMwzF2lTH8pyv8yeZRodItP2IVlzzmBuD1M7BjawWgg9XAvktqJJ91Qjgoaf8qJpHQ8FEU9VxRfOkLhh86QA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.3.0"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
@@ -3419,83 +3431,33 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.0.tgz",
-      "integrity": "sha512-NaLMF8IVlsLm9yIDKD6jKwlgMBnO8KFTy1XFVwBd3LitkT83Bn0XfW/Q0sMC+eIY6F5tc/sIsVfgr+gfimxy6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-4.2.2.tgz",
+      "integrity": "sha512-Fn7pl0ddhHxRtVbU7DY4qNujWsLVTIBZ9MAMIfmr+0TUp1a0P0KYb1/bO7gkbu2d1sjChrpv8az3lM9aVX6WeQ==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
-        "@edx/paragon": "20.28.5",
+        "@edx/paragon": "20.45.0",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
         "@fortawesome/free-regular-svg-icons": "6.3.0",
         "@fortawesome/free-solid-svg-icons": "6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@reduxjs/toolkit": "1.9.5",
+        "axios-mock-adapter": "1.21.5",
         "babel-polyfill": "6.26.0",
+        "classnames": "2.3.2",
+        "lodash": "4.17.21",
+        "react-redux": "7.2.9",
         "react-responsive": "8.2.0",
-        "react-transition-group": "4.4.5"
+        "react-router-dom": "5.3.4",
+        "react-transition-group": "4.4.5",
+        "rosie": "2.1.0",
+        "timeago.js": "4.0.2"
       },
       "peerDependencies": {
+        "@edx/frontend-platform": "^4.0.0",
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-header/node_modules/@edx/paragon": {
-      "version": "20.28.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.5.tgz",
-      "integrity": "sha512-6cW9Pl1hojOGfGatLjeojzr0qNfil6rlwB3APKZlgomscDxVzYbaQYyZNOx/k2dFaO8EKCpiApXhHW+WihQipg==",
-      "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.1.1",
-        "@fortawesome/react-fontawesome": "^0.1.18",
-        "@popperjs/core": "^2.11.4",
-        "bootstrap": "^4.6.2",
-        "classnames": "^2.3.1",
-        "email-prop-type": "^3.0.0",
-        "file-selector": "^0.6.0",
-        "font-awesome": "^4.7.0",
-        "glob": "^8.0.3",
-        "lodash.uniqby": "^4.7.0",
-        "mailto-link": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-bootstrap": "^1.6.5",
-        "react-dropzone": "^14.2.1",
-        "react-focus-on": "^3.5.4",
-        "react-loading-skeleton": "^3.1.0",
-        "react-popper": "^2.2.5",
-        "react-proptype-conditional-require": "^1.0.4",
-        "react-responsive": "^8.2.0",
-        "react-table": "^7.7.0",
-        "react-transition-group": "^4.4.2",
-        "tabbable": "^5.3.3",
-        "uncontrollable": "^7.2.1",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0",
-        "react-intl": "^5.25.1"
-      }
-    },
-    "node_modules/@edx/frontend-component-header/node_modules/@edx/paragon/node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
-      "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.x"
-      }
-    },
-    "node_modules/@edx/frontend-component-header/node_modules/@edx/paragon/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@edx/frontend-component-header/node_modules/@fortawesome/fontawesome-common-types": {
@@ -3565,49 +3527,61 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/@edx/frontend-component-header/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "node_modules/@edx/frontend-component-header/node_modules/history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
-    "node_modules/@edx/frontend-component-header/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+    "node_modules/@edx/frontend-component-header/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "isarray": "0.0.1"
       }
     },
-    "node_modules/@edx/frontend-component-header/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+    "node_modules/@edx/frontend-component-header/node_modules/react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
-      "engines": {
-        "node": ">=10"
+      "peerDependencies": {
+        "react": ">=15"
       }
     },
-    "node_modules/@edx/frontend-component-header/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/@edx/frontend-component-header/node_modules/react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
       }
     },
     "node_modules/@edx/frontend-platform": {
@@ -3694,9 +3668,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.30.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.30.0.tgz",
-      "integrity": "sha512-8pl+D6v2PCgRspaZ5lWj77vZgoYuxsP8kAMkgEcusvCJdaUIihpd28vDvA+iWlG8TlzmYE3qCcPw2P/0v70fsA==",
+      "version": "20.45.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.45.0.tgz",
+      "integrity": "sha512-9lHcnSJ36sQ+bsYFhydf/Pvp3Bo5N3go8R3ORPTNtvYnwiKSfjlv11QpURC/xHobXsT2eYHiwl2gNmq1yP09BA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -6271,14 +6245,14 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
-      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
       "dependencies": {
-        "immer": "^9.0.7",
-        "redux": "^4.1.2",
-        "redux-thunk": "^2.4.1",
-        "reselect": "^4.1.5"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -6294,17 +6268,17 @@
       }
     },
     "node_modules/@reduxjs/toolkit/node_modules/redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "peerDependencies": {
         "redux": "^4"
       }
@@ -8688,10 +8662,9 @@
       }
     },
     "node_modules/axios-mock-adapter": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.1.tgz",
-      "integrity": "sha512-Pdm7nZuhkz/DSucQ4Bbo9qVBqfm9j7ev9ycTvIXHqvAjnJEjWPHKYfTfpounVp8MwjFFSHXGS7hCkTwAswtSTA==",
-      "dev": true,
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
+      "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "is-buffer": "^2.0.5"
@@ -9775,9 +9748,9 @@
       }
     },
     "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.0",
@@ -14944,9 +14917,9 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/immer": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -15236,7 +15209,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25905,9 +25877,9 @@
       "integrity": "sha512-nopsRn7KnGgazBe2c3H2+Kf+Csp6PGDRLiBkYEDMKY8o/EIgft/WnIm/OnAKTawZiLnJXHAqhpFBddvs6NiXlw=="
     },
     "node_modules/react-redux": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -26665,9 +26637,9 @@
       "dev": true
     },
     "node_modules/reselect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
-      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -26790,6 +26762,14 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rosie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rosie/-/rosie-2.1.0.tgz",
+      "integrity": "sha512-Dbzdc+prLXZuB/suRptDnBUY29SdGvND3bLg6cll8n7PNqzuyCxSlRfrkn8PqjS9n4QVsiM7RCvxCkKAkTQRjA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/rst-selector-parser": {
@@ -29426,6 +29406,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/timeago.js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
+      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
-    "@edx/frontend-component-footer": "^11.7.0",
-    "@edx/frontend-component-header": "^3.7.0",
+    "@edx/frontend-component-footer": "^12.0.0",
+    "@edx/frontend-component-header": "^4.2.2",
     "@edx/frontend-platform": "^4.1.0",
     "@edx/paragon": "^20.30.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/src/components/FilePreview/FileInfo.jsx
+++ b/src/components/FilePreview/FileInfo.jsx
@@ -26,7 +26,7 @@ export const FileInfo = ({ onClick, children }) => (
     )}
   >
     <Button
-      size="small"
+      size="sm"
       variant="tertiary"
       onClick={onClick}
       iconAfter={InfoOutline}

--- a/src/components/FilePreview/__snapshots__/FileInfo.test.jsx.snap
+++ b/src/components/FilePreview/__snapshots__/FileInfo.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`File Preview Card component snapshot 1`] = `
   <Button
     iconAfter={[MockFunction icons.InfoOutline]}
     onClick={[MockFunction this.props.onClick]}
-    size="small"
+    size="sm"
     variant="tertiary"
   >
     <FormattedMessage

--- a/src/test/app.test.jsx
+++ b/src/test/app.test.jsx
@@ -40,6 +40,11 @@ jest.mock('@edx/frontend-platform/auth', () => ({
   getLoginRedirectUrl: jest.fn(),
 }));
 
+jest.mock('@edx/frontend-component-header', () => ({
+  LearningHeader: () => 'Header',
+}));
+// jest.mock('@edx/frontend-component-footer', () => () => 'Footer');
+
 jest.mock('react-pdf', () => ({
   Document: () => <div>Document</div>,
   Image: () => <div>Image</div>,
@@ -213,7 +218,7 @@ describe('ESG app integration tests', () => {
     inspector = new Inspector(el);
   });
 
-  test('initialization', async (done) => {
+  test('initialization', async () => {
     const verifyInitialState = async () => {
       await waitForRequestStatus(RequestKeys.initialize, RequestStates.pending);
       const testInitialState = (key) => expect(
@@ -275,7 +280,6 @@ describe('ESG app integration tests', () => {
 
     await makeTableSelections();
     await waitForRequestStatus(RequestKeys.fetchSubmission, RequestStates.pending);
-    done();
   });
 
   describe('initialized', () => {
@@ -286,7 +290,7 @@ describe('ESG app integration tests', () => {
       await waitForRequestStatus(RequestKeys.fetchSubmission, RequestStates.pending);
     });
 
-    test('initial review state', async (done) => {
+    test('initial review state', async () => {
       // Make table selection and load Review pane
       expect(
         state.grading.selection,
@@ -304,10 +308,9 @@ describe('ESG app integration tests', () => {
         inspector.review.loadingResponse(),
         'Loading Responses pending state text should be displayed in the ReviewModal',
       ).toBeVisible();
-      done();
     });
 
-    test('fetch network error and retry', async (done) => {
+    test('fetch network error and retry', async () => {
       await resolveFns.fetch.networkError();
       await waitForRequestStatus(RequestKeys.fetchSubmission, RequestStates.failed);
       expect(
@@ -317,10 +320,9 @@ describe('ESG app integration tests', () => {
       // fetch: retry and succeed
       await userEvent.click(inspector.review.retryFetchLink());
       await waitForRequestStatus(RequestKeys.fetchSubmission, RequestStates.pending);
-      done()
     });
 
-    test('fetch success and nav chain', async (done) => {
+    test('fetch success and nav chain', async () => {
       let showRubric = false;
       // fetch: success with chained navigation
       const verifyFetchSuccess = async (submissionIndex) => {
@@ -396,7 +398,6 @@ describe('ESG app integration tests', () => {
         await userEvent.click(inspector.review.prevNav());
         await verifyFetchSuccess(i);
       }
-      done();
     });
 
     describe('grading (basic)', () => {
@@ -416,7 +417,7 @@ describe('ESG app integration tests', () => {
         const overallFeedback = 'some overall feedback';
 
         // Set basic grade and feedback
-        const setGrade = async (done) => {
+        const setGrade = async () => {
           const {
             criterionOption,
             criterionFeedback,
@@ -487,18 +488,17 @@ describe('ESG app integration tests', () => {
           });
         */
         test('grade and submit',
-          async (done) => {
+          async () => {
             expect(await inspector.find.review.submitGradeBtn()).toBeVisible();
             await setGrade();
             checkGradingState();
             await userEvent.click(inspector.review.rubric.submitGradeBtn());
             await resolveFns.updateGrade.success();
             checkGradeSuccess();
-            done();
           },
         );
         test('grade, navigate, and return, maintaining gradingState',
-          async (done) => {
+          async () => {
             expect(await inspector.find.review.submitGradeBtn()).toBeVisible();
             await setGrade();
             checkGradingState();
@@ -507,7 +507,6 @@ describe('ESG app integration tests', () => {
             await loadPrev();
             await waitForEqual(() => getState().grading.activeIndex, 0, 'activeIndex');
             checkGradingState();
-            done();
           },
         );
       });


### PR DESCRIPTION
In light for adding renovate to the repo, I want to make sure that this doesn't block the future package update. Because header/footer have conflict peer dependency, it prevent `npm update` from running properlly.