### PR TITLE
chore: change renovate to daily to for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    "schedule:weekly",
+    "schedule:daily",
     ":automergeLinters",
     ":automergeMinor",
     ":automergeTesters",


### PR DESCRIPTION
In relation to https://github.com/openedx/axim-engineering/issues/810 the renovate job doesn't seem to get run. This pr was to test renovate to run daily until the first merge.