### PR TITLE
fix: replace edx.org brand dependency with openedx brand (#199)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+        "@edx/brand": "npm:@edx/brand-openedx@^1.2.0",
         "@edx/frontend-component-footer": "12.2.1",
         "@edx/frontend-component-header": "4.6.0",
         "@edx/frontend-platform": "4.6.1",
@@ -2099,10 +2099,10 @@
       }
     },
     "node_modules/@edx/brand": {
-      "name": "@edx/brand-edx.org",
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.1.2.tgz",
-      "integrity": "sha512-pBhUuegRg+2k63LWe3vyQDCdAiWTduaJ3hpHWqLZC3wYYyAyour6VGUbS1m9kg3+BmLz6AZR9P10BXT0iso6XQ=="
+      "name": "@edx/brand-openedx",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
+      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg=="
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+    "@edx/brand": "npm:@edx/brand-openedx@^1.2.0",
     "@edx/frontend-component-footer": "12.2.1",
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-platform": "4.6.1",


### PR DESCRIPTION
@edx/brand-edx.org package is not open source. @edx/brand-openedx is what is used by other MFEs by default.

[Similar PR in gradebook](https://github.com/openedx/frontend-app-gradebook/pull/327/commits/d30aad93340d5e9e551f9343a10d37dc2cf239c9)