### PR TITLE
chore: update schedule to widen the range renovate to update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,6 @@
       "automerge": true
     }
   ],
-  "timezone": "America/New_York"
+  "timezone": "America/New_York",
+  "schedule": ["before 11pm"]
 }


### PR DESCRIPTION
It's always skipping it because it's never running before 4am. This pr is use as a test to figure what went wrong with renovate setting for this project.