### PR TITLE
Fateme khodayari/fix oras with files

### DIFF
--- a/src/components/FilePreview/Banners/ErrorBanner.jsx
+++ b/src/components/FilePreview/Banners/ErrorBanner.jsx
@@ -10,7 +10,7 @@ const messageShape = PropTypes.shape({
   defaultMessage: PropTypes.string,
 });
 
-export const ErrorBanner = ({ actions, headingMessage, children }) => {
+export const ErrorBanner = ({ actions, headerMessage, children }) => {
   const actionButtons = actions.map(action => (
     <Button key={action.id} onClick={action.onClick} variant="outline-primary">
       <FormattedMessage {...action.message} />
@@ -19,7 +19,7 @@ export const ErrorBanner = ({ actions, headingMessage, children }) => {
   return (
     <Alert variant="danger" icon={Info} actions={actionButtons}>
       <Alert.Heading>
-        <FormattedMessage {...headingMessage} />
+        <FormattedMessage {...headerMessage} />
       </Alert.Heading>
       {children}
     </Alert>
@@ -37,7 +37,7 @@ ErrorBanner.propTypes = {
       message: messageShape,
     }),
   ),
-  headingMessage: messageShape.isRequired,
+  headerMessage: messageShape.isRequired,
   children: PropTypes.node,
 };
 

--- a/src/components/FilePreview/hooks.js
+++ b/src/components/FilePreview/hooks.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { getConfig } from '@edx/frontend-platform';
+
 import { StrictDict } from 'utils';
 import { ErrorStatuses } from 'data/constants/requests';
 import { FileTypes } from 'data/constants/files';
@@ -87,7 +89,7 @@ export const renderHooks = ({
   const Renderer = module.RENDERERS[module.getFileType(file.name)];
   const rendererProps = {
     fileName: file.name,
-    url: file.downloadUrl,
+    url: `${getConfig().LMS_BASE_URL}${file.downloadUrl}`,
     onError: stopLoading,
     onSuccess: () => stopLoading(),
   };

--- a/src/data/redux/thunkActions/download.js
+++ b/src/data/redux/thunkActions/download.js
@@ -1,6 +1,8 @@
 import * as zip from '@zip.js/zip.js';
 import FileSaver from 'file-saver';
 
+import { getConfig } from '@edx/frontend-platform';
+
 import { RequestKeys } from 'data/constants/requests';
 import { selectors } from 'data/redux';
 import { locationId } from 'data/constants/app';
@@ -98,6 +100,9 @@ export const downloadBlobs = async (files) => {
 export const getSubmissionFiles = async (submissionUUID) => {
   try {
     const { files } = await api.fetchSubmissionFiles(submissionUUID);
+    files.forEach((file) => {
+      file.downloadUrl = `${getConfig().LMS_BASE_URL}${file.downloadUrl}`;
+    });
     return files;
   } catch {
     throw FetchSubmissionFilesException();

--- a/src/data/redux/thunkActions/download.js
+++ b/src/data/redux/thunkActions/download.js
@@ -94,16 +94,27 @@ export const downloadBlobs = async (files) => {
 };
 
 /**
+ * @param {Array} files
+ * @returns Array
+ */
+export const fixFileDownloadUrl = (files) => {
+  const { LMS_BASE_URL } = getConfig();
+  files.map((file) => {
+    const fixedFile = file;
+    fixedFile.downloadUrl = `${LMS_BASE_URL}${file.downloadUrl}`;
+    return fixedFile;
+  });
+  return files;
+};
+
+/**
  * @param {string} submissionUUID
  * @returns Promise
  */
 export const getSubmissionFiles = async (submissionUUID) => {
   try {
     const { files } = await api.fetchSubmissionFiles(submissionUUID);
-    files.forEach((file) => {
-      file.downloadUrl = `${getConfig().LMS_BASE_URL}${file.downloadUrl}`;
-    });
-    return files;
+    return fixFileDownloadUrl(files);
   } catch {
     throw FetchSubmissionFilesException();
   }


### PR DESCRIPTION
In the palm 3 version of openedx the download url provided for files of ORAs in not having the LMS base url and is only the path. This causes file preview and download to fail. After the preview failure, the error banner is show which again fails due to name mismatch in the component arguments (was `HeadingMessage` but must be `HeaderMessage`)

### Test Plan
To test the issue, first follow the steps described in the "How to reproduce" section of [this issue](https://github.com/openedx/frontend-app-ora-grading/issues/285) to create and submit an ORA with file upload. Now this time with the committed changes, the app won't crash and the preview and download features will be fine.

Closes [285](https://github.com/openedx/frontend-app-ora-grading/issues/285)