### PR TITLE
fix: request error for empty user list responses

### DIFF
--- a/src/containers/ListView/TableAction.jsx
+++ b/src/containers/ListView/TableAction.jsx
@@ -11,6 +11,7 @@ export const TableAction = ({ tableInstance, handleClick }) => (
     onClick={handleClick(tableInstance.rows)}
     variant="primary"
     className="view-all-responses-btn"
+    disabled={tableInstance.rows.length === 0}
   >
     <FormattedMessage {...messages.viewAllResponses} />
   </Button>

--- a/src/containers/ListView/TableAction.test.jsx
+++ b/src/containers/ListView/TableAction.test.jsx
@@ -13,6 +13,15 @@ describe('TableAction component', () => {
     expect(el).toMatchSnapshot();
   });
 
+  test('Inactive Button "View All Responses"', () => {
+    const emptyProps = {
+      tableInstance: { rows: [] },
+      handleClick: jest.fn(),
+    };
+    const el = shallow(<TableAction {...emptyProps} />);
+    expect(el.snapshot).toMatchSnapshot();
+  });
+
   test('handleClick', () => {
     shallow(<TableAction {...props} />);
     expect(props.handleClick).toHaveBeenCalledWith(props.tableInstance.rows);

--- a/src/containers/ListView/__snapshots__/TableAction.test.jsx.snap
+++ b/src/containers/ListView/__snapshots__/TableAction.test.jsx.snap
@@ -1,8 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableAction component Inactive Button "View All Responses" 1`] = `undefined`;
+
 exports[`TableAction component snapshots 1`] = `
 <Button
   className="view-all-responses-btn"
+  disabled={false}
   onClick={[MockFunction]}
   variant="primary"
 >

--- a/src/data/redux/thunkActions/grading.js
+++ b/src/data/redux/thunkActions/grading.js
@@ -35,9 +35,11 @@ export const loadPrev = () => (dispatch) => {
  * @param {string[]} submissionUUIDs - ordered list of submissionUUIDs for selected submissions
  */
 export const loadSelectionForReview = (submissionUUIDs) => (dispatch) => {
-  dispatch(actions.grading.updateSelection(submissionUUIDs));
-  dispatch(actions.app.setShowReview(true));
-  dispatch(module.loadSubmission());
+  if (submissionUUIDs?.length > 0) {
+    dispatch(actions.grading.updateSelection(submissionUUIDs));
+    dispatch(actions.app.setShowReview(true));
+    dispatch(module.loadSubmission());
+  }
 };
 
 export const loadSubmission = () => (dispatch, getState) => {

--- a/src/data/redux/thunkActions/grading.test.js
+++ b/src/data/redux/thunkActions/grading.test.js
@@ -107,19 +107,24 @@ describe('grading thunkActions', () => {
       });
     });
     describe('loadSelectionForReview', () => {
-      const submissionUUIDs = [
-        'submission-id-0',
-        'submission-id-1',
-        'submission-id-2',
-        'submission-id-3',
-      ];
       test('dispatches actions.grading.updateSelection, actions.app.setShowReview(true), and then loadSubmission', () => {
+        const submissionUUIDs = [
+          'submission-id-0',
+          'submission-id-1',
+          'submission-id-2',
+          'submission-id-3',
+        ];
         thunkActions.loadSelectionForReview(submissionUUIDs)(dispatch, getState);
         expect(dispatch.mock.calls).toEqual([
           [actions.grading.updateSelection(submissionUUIDs)],
           [actions.app.setShowReview(true)],
           [thunkActions.loadSubmission()],
         ]);
+      });
+      test('with empty submissionUUIDs does not dispatch any action', () => {
+        const submissionUUIDs = [];
+        thunkActions.loadSelectionForReview(submissionUUIDs)(dispatch, getState);
+        expect(dispatch).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
This is [backport](https://github.com/openedx/frontend-app-ora-grading/pull/291) from the master.

### Description:

"An unexpected error occurred" if you try to get all responses when the users' list is empty:

1. Open ORA Grading:

![111](https://github.com/openedx/frontend-app-ora-grading/assets/98233552/7acd8882-13d8-451b-b6ec-6b9031d80c78)

2. In Search username fill in not existing student username:

![222](https://github.com/openedx/frontend-app-ora-grading/assets/98233552/93f0ad46-a5d8-473d-9afb-d3fba1459df0)

3. Click on **View all responses**:

![333](https://github.com/openedx/frontend-app-ora-grading/assets/98233552/89f631a8-a18d-4723-8cea-46a21e30e150)


**I suggest not sending a request if the users are not on the list.**