### PR TITLE
fix: test problems jest dom and paragon

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,4 +18,8 @@ module.exports = createConfig('jest', {
   ],
   testTimeout: 120000,
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@openedx/paragon$': '<rootDir>/mockParagon.js',
+    '^@openedx/paragon/(.*)$': '<rootDir>/mockParagon.js',
+  },
 });

--- a/mockParagon.js
+++ b/mockParagon.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';
+// breaking change here: https://github.com/testing-library/jest-dom/releases/tag/v6.0.0
 
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';


### PR DESCRIPTION
#### Description

Currently, after running "npm run test", tests will fail due to an update of @testing-library/jest-dom to v6.0.0, which has a breaking change that removes the import of @testing-library/jest-dom/extend-expect. After fixing that, you will encounter a problem with @openedx/paragon. With this fix, the tests will run properly.

Issue: https://github.com/openedx/frontend-app-ora-grading/issues/310

<img width="337" alt="Screen Shot 2024-01-31 at 11 13 05 AM" src="https://github.com/openedx/frontend-app-ora-grading/assets/134975835/6eb3a25e-d8b8-405a-8f6e-c6dc67bcc2f8">

#### How to tes it

``` 
git fetch origin pull/311/head:jv/fix-test-problems
git checkout jv/fix-test-problems
npm run test
```


