### PR TITLE
feat: tutor-mfe compatiblilty for `atlas pull` | FC-0012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,14 @@ pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
-	  && atlas pull --filter=$(transifex_langs) \
+	  && atlas pull $(ATLAS_OPTIONS) \
 	           translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
+	           translations/frontend-platform/src/i18n/messages:frontend-platform \
 	           translations/paragon/src/i18n/messages:paragon \
 	           translations/frontend-app-ora-grading/src/i18n/messages:frontend-app-ora-grading
 
-	$(intl_imports) frontend-component-footer frontend-component-header paragon frontend-app-ora-grading
+	$(intl_imports) frontend-component-footer frontend-component-header frontend-platform paragon frontend-app-ora-grading
 endif
 
 # This target is used by CI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@edx/frontend-component-footer": "12.7.1",
         "@edx/frontend-component-header": "4.11.1",
         "@edx/frontend-platform": "5.6.1",
+        "@edx/openedx-atlas": "^0.6.0",
         "@edx/paragon": "^20.44.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -3268,6 +3269,14 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.0.tgz",
+      "integrity": "sha512-wZO7hA4VJ/bXjaQNNR7KXGYyTCNs1mBJd3HwQK2EmOwFZYFNX6nzSAm9S7HCfi/kb1PCRpmp3wJt+v/Eu9BEQg==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/paragon": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@edx/frontend-component-footer": "12.7.1",
     "@edx/frontend-component-header": "4.11.1",
     "@edx/frontend-platform": "5.6.1",
+    "@edx/openedx-atlas": "^0.6.0",
     "@edx/paragon": "^20.44.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",


### PR DESCRIPTION


Similar to https://github.com/openedx/frontend-app-communications/pull/187.

## Changes

 - install atlas
 - remove `--filter` to pull all languages by default
 - use ATLAS_OPTIONS to allow custom `--filter`
 - include frontend-platform in `atlas pull`

## Refs
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
