### PR TITLE
feat: Add header styles inclusion

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -10,6 +10,7 @@ $fa-font-path: "~font-awesome/fonts";
 $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.0.0 to work
 
 @import "~@edx/frontend-component-footer/dist/_footer";
+@import "~@edx/frontend-component-header/dist/index";
 
 #root {
   display: flex;


### PR DESCRIPTION
This is backport from master branch - https://github.com/openedx/frontend-app-ora-grading/pull/321

Header styles inclusion like it done in frontend-app-learning - https://github.com/openedx/frontend-app-learning/blob/master/src/index.scss#L7

It can be useful, for example, for the potential using of cookie banner