### PR TITLE
fix: "An unexpected error occurred" for ORA response with corrupted attached file

### DIFF
--- a/src/components/FilePreview/Banners/ErrorBanner.jsx
+++ b/src/components/FilePreview/Banners/ErrorBanner.jsx
@@ -19,7 +19,7 @@ export const ErrorBanner = ({ actions, headingMessage, children }) => {
   return (
     <Alert variant="danger" icon={Info} actions={actionButtons}>
       <Alert.Heading>
-        <FormattedMessage {...headingMessage} />
+        {headingMessage ? <FormattedMessage {...headingMessage} /> : null}
       </Alert.Heading>
       {children}
     </Alert>


### PR DESCRIPTION
### Steps to Reproduce:
1. Answer by the user to ORA -> attach corrupted file.
1. As staff go to Instructors tab -> Open responses and choose ora -> Click on View all responses

### Actual Result:
An unexpected error occurred. Please click the button below to refresh the page:

<img width="2033" alt="Знімок екрана 2024-03-21 о 19 45 20" src="https://github.com/openedx/frontend-app-ora-grading/assets/98233552/05b7d330-b5c4-4860-bad4-b5f61bd3952f">

---
After my edits, it will be displayed in the preview card:

<img width="2033" alt="Знімок екрана 2024-03-21 о 19 21 09" src="https://github.com/openedx/frontend-app-ora-grading/assets/98233552/07965901-7f05-4a2c-8a78-3ca90d47dabc">

---
### Note:
I couldn’t figure out how to change the not-very-correct error message `Unknown errors` without major modifications.
[Here](https://github.com/openedx/frontend-app-ora-grading/blob/59a7d0751bcac8f9e396e83e8995a1f78d74d40e/src/components/FilePreview/hooks.js#L73) you can select an error message.