### PR TITLE
fix: incorrect message for locking for Quince

### DIFF
--- a/src/containers/ReviewModal/ReviewErrors/LockErrors.jsx
+++ b/src/containers/ReviewModal/ReviewErrors/LockErrors.jsx
@@ -16,7 +16,7 @@ import ReviewError from './ReviewError';
  */
 export class LockErrors extends React.Component {
   get errorProp() {
-    if (this.props.errorStatus === ErrorStatuses.forbidden) {
+    if (this.props.errorStatus === ErrorStatuses.conflict) {
       return {
         heading: messages.errorLockContestedHeading,
         message: messages.errorLockContested,

--- a/src/containers/ReviewModal/ReviewErrors/LockErrors.test.jsx
+++ b/src/containers/ReviewModal/ReviewErrors/LockErrors.test.jsx
@@ -42,7 +42,7 @@ describe('LockErrors component', () => {
         expect(el.instance().render()).toMatchSnapshot();
       });
       test('snapshot: error with conflicted lock', () => {
-        el.setProps({ errorStatus: ErrorStatuses.forbidden });
+        el.setProps({ errorStatus: ErrorStatuses.conflict });
         expect(el.instance().render()).toMatchSnapshot();
       });
     });


### PR DESCRIPTION
**This is a [backport](https://github.com/openedx/frontend-app-ora-grading/pull/326) from the master.**

## Description:

### Reproduction steps:
1. Two Staff go to Instructors tab
2. Open responses and choose ORA
3. By each staff choose user answer
4. By first staff click on "Start grading" button
5. By second staff click on "Start grading" button

Then for the second Staff it will be displayed:
<img width="2042" alt="screen_63" src="https://github.com/openedx/frontend-app-ora-grading/assets/98233552/b751e0be-2a28-470c-860c-af6bb3ad839f">

The message selection process was incorrect because a 409 was received from the server (as intended).

Now this message is displayed:
<img width="1041" alt="screen_64" src="https://github.com/openedx/frontend-app-ora-grading/assets/98233552/feda06b5-731a-4d4d-90a1-634f66cf5bdf">
