### PR TITLE
feat: Images sizes and src link, blockquote styles (quince.master)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -49,7 +49,22 @@ $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.
       right: 1rem !important;
     }
   }
+
   .confirm-modal .pgn__modal-body {
     overflow: hidden;
+  }
+
+  .pgn__modal-body-content {
+    & img {
+      object-fit: contain;
+      max-width: 100%;
+      height: auto;
+    }
+
+    & blockquote > p {
+      border-left: 2px solid $gray-200;
+      margin-left: 1.5rem;
+      padding-left: 1rem;
+    }
   }
 }

--- a/src/containers/ResponseDisplay/index.jsx
+++ b/src/containers/ResponseDisplay/index.jsx
@@ -11,6 +11,7 @@ import parse from 'html-react-parser';
 import { selectors } from 'data/redux';
 import { fileUploadResponseOptions } from 'data/services/lms/constants';
 
+import { getConfig } from '@edx/frontend-platform';
 import SubmissionFiles from './SubmissionFiles';
 import PreviewDisplay from './PreviewDisplay';
 
@@ -26,7 +27,13 @@ export class ResponseDisplay extends React.Component {
   }
 
   get textContents() {
-    return this.props.response.text.map(text => parse(this.purify.sanitize(text)));
+    const { text } = this.props.response;
+
+    const formattedText = text
+      .map((item) => item.replaceAll(/\.\.\/asset/g, `${getConfig().LMS_BASE_URL}/asset`))
+      .map((item) => parse(this.purify.sanitize(item)));
+
+    return formattedText;
   }
 
   get submittedFiles() {


### PR DESCRIPTION
- Fixed images size
- Fixed images source link
- Fixed blockquote styles

![Screenshot 2024-06-10 at 11 37 51](https://github.com/openedx/frontend-app-ora-grading/assets/138868841/511d31f8-6f01-4a50-bf27-11d9019f98ec)
![Screenshot 2024-06-10 at 11 38 16](https://github.com/openedx/frontend-app-ora-grading/assets/138868841/fe4a26e5-8cab-4a00-8c9c-4063fb0925b9)

#### Related Pull Requests

- master - https://github.com/openedx/frontend-app-ora-grading/pull/333
- quince.master - https://github.com/openedx/frontend-app-ora-grading/pull/334
- redwood.master - https://github.com/openedx/frontend-app-ora-grading/pull/335