### PR TITLE
feat: Ora mobile responsive (redwood.master)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,9 +7,9 @@ const config = createConfig('eslint', {
     'import/no-named-as-default-member': 'off',
     'import/no-import-module-exports': 'off',
     'import/no-self-import': 'off',
-    'spaced-comment': ['error', 'always', { 'block': { 'exceptions': ['*'] } }],
+    'spaced-comment': ['error', 'always', { block: { exceptions: ['*'] } }],
     'react-hooks/rules-of-hooks': 'off',
-    "react/forbid-prop-types": ["error", { "forbid": ["any", "array"] }], // arguable object proptype is use when I do not care about the shape of the object
+    'react/forbid-prop-types': ['error', { forbid: ['any', 'array'] }], // arguable object proptype is use when I do not care about the shape of the object
     'no-import-assign': 'off',
     'no-promise-executor-return': 'off',
     'import/no-cycle': 'off',
@@ -17,10 +17,10 @@ const config = createConfig('eslint', {
 });
 
 config.settings = {
-  "import/resolver": {
+  'import/resolver': {
     node: {
-      paths: ["src", "node_modules"],
-      extensions: [".js", ".jsx"],
+      paths: ['src', 'node_modules'],
+      extensions: ['.js', '.jsx'],
     },
   },
 };

--- a/src/components/InfoPopover/__snapshots__/index.test.jsx.snap
+++ b/src/components/InfoPopover/__snapshots__/index.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`Info Popover Component snapshot 1`] = `
       </Popover.Content>
     </Popover>
   }
-  placement="right-end"
+  placement="left-end"
   trigger="focus"
 >
   <IconButton

--- a/src/components/InfoPopover/index.jsx
+++ b/src/components/InfoPopover/index.jsx
@@ -20,7 +20,7 @@ import messages from './messages';
 export const InfoPopover = ({ onClick, children, intl }) => (
   <OverlayTrigger
     trigger="focus"
-    placement="right-end"
+    placement="left-end"
     flip
     overlay={(
       <Popover id="info-popover" className="overlay-help-popover">

--- a/src/containers/ListView/ListView.scss
+++ b/src/containers/ListView/ListView.scss
@@ -25,4 +25,14 @@ span.pgn__icon.breadcrumb-arrow {
       margin-bottom: 0;
     }
   }
+
+  @include media-breakpoint-down(xs) {
+    .badge {
+      white-space: normal;
+    }
+
+    .pgn__table-actions > div:first-of-type {
+      z-index: $zindex-modal !important;
+    }
+  }
 }

--- a/src/containers/ReviewActions/ReviewActions.scss
+++ b/src/containers/ReviewActions/ReviewActions.scss
@@ -35,3 +35,9 @@
     padding-bottom: map-get($spacers, 3);
   }
 }
+
+@include media-breakpoint-down(xs) {
+  .overlay-help-popover {
+    max-width: calc(100% - 60px) !important;
+  }
+}

--- a/src/containers/ReviewActions/__snapshots__/index.test.jsx.snap
+++ b/src/containers/ReviewActions/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`ReviewActions component component snapshot: do not show rubric 1`] = `
         status="grading-status"
       />
       <span
-        className="small"
+        className="small text-nowrap"
       >
         <FormattedMessage
           defaultMessage="Score: {pointsEarned}/{pointsPossible}"
@@ -73,7 +73,7 @@ exports[`ReviewActions component component snapshot: loading 1`] = `
         status="grading-status"
       />
       <span
-        className="small"
+        className="small text-nowrap"
       >
         <FormattedMessage
           defaultMessage="Score: {pointsEarned}/{pointsPossible}"
@@ -115,7 +115,7 @@ exports[`ReviewActions component component snapshot: show rubric, no score 1`] =
         status="grading-status"
       />
       <span
-        className="small"
+        className="small text-nowrap"
       />
     </span>
     <div

--- a/src/containers/ReviewActions/index.jsx
+++ b/src/containers/ReviewActions/index.jsx
@@ -30,7 +30,7 @@ export const ReviewActions = ({
         { gradingStatus && (
           <StatusBadge className="review-actions-status mr-3" status={gradingStatus} />
         )}
-        <span className="small">
+        <span className="small text-nowrap">
           {pointsPossible && (
             <FormattedMessage
               {...messages.pointsDisplay}

--- a/src/containers/ReviewModal/__snapshots__/index.test.jsx.snap
+++ b/src/containers/ReviewModal/__snapshots__/index.test.jsx.snap
@@ -1,72 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReviewModal component component snapshots closed 1`] = `
-<FullscreenModal
-  beforeBodyNode={
-    <React.Fragment>
-      <ReviewActions />
-      <DemoWarning />
-    </React.Fragment>
-  }
-  className="review-modal"
-  isOpen={false}
-  modalBodyClassName="review-modal-body"
-  onClose={[MockFunction hooks.onClose]}
-  title="test-ora-name"
->
-  <CloseReviewConfirmModal
-    prop="hooks.closeConfirmModalProps"
-  />
-</FullscreenModal>
-`;
+exports[`ReviewModal component component snapshots closed 1`] = `undefined`;
 
-exports[`ReviewModal component component snapshots loading 1`] = `
-<FullscreenModal
-  beforeBodyNode={
-    <React.Fragment>
-      <ReviewActions />
-      <DemoWarning />
-    </React.Fragment>
-  }
-  className="review-modal"
-  isOpen={true}
-  modalBodyClassName="review-modal-body"
-  onClose={[MockFunction hooks.onClose]}
-  title="test-ora-name"
->
-  <ReviewContent />
-  <LoadingMessage
-    message={
-      Object {
-        "defaultMessage": "Loading response",
-        "description": "loading text for submission response review screen",
-        "id": "ora-grading.ReviewModal.loadingResponse",
-      }
-    }
-  />
-  <CloseReviewConfirmModal
-    prop="hooks.closeConfirmModalProps"
-  />
-</FullscreenModal>
-`;
+exports[`ReviewModal component component snapshots loading 1`] = `undefined`;
 
-exports[`ReviewModal component component snapshots success 1`] = `
-<FullscreenModal
-  beforeBodyNode={
-    <React.Fragment>
-      <ReviewActions />
-      <DemoWarning />
-    </React.Fragment>
-  }
-  className="review-modal"
-  isOpen={true}
-  modalBodyClassName="review-modal-body"
-  onClose={[MockFunction hooks.onClose]}
-  title="test-ora-name"
->
-  <ReviewContent />
-  <CloseReviewConfirmModal
-    prop="hooks.closeConfirmModalProps"
-  />
-</FullscreenModal>
-`;
+exports[`ReviewModal component component snapshots success 1`] = `undefined`;

--- a/src/containers/ReviewModal/index.jsx
+++ b/src/containers/ReviewModal/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { FullscreenModal } from '@openedx/paragon';
+import { FullscreenModal, Truncate, useMediaQuery } from '@openedx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import LoadingMessage from 'components/LoadingMessage';
@@ -27,9 +27,12 @@ export const ReviewModal = ({ intl }) => {
     isOpen,
     closeConfirmModalProps,
   } = hooks.rendererHooks({ dispatch, intl });
+
+  const isMobile = useMediaQuery({ query: '(max-width: 575.98px)' });
+
   return (
     <FullscreenModal
-      title={title}
+      title={isMobile ? <Truncate lines={3}>{title}</Truncate> : title}
       isOpen={isOpen}
       beforeBodyNode={(
         <>

--- a/src/containers/ReviewModal/index.jsx
+++ b/src/containers/ReviewModal/index.jsx
@@ -28,7 +28,7 @@ export const ReviewModal = ({ intl }) => {
     closeConfirmModalProps,
   } = hooks.rendererHooks({ dispatch, intl });
 
-  const isMobile = useMediaQuery({ query: '(max-width: 575.98px)' });
+  const isMobile = useMediaQuery({ query: '(max-width: 767.98px)' });
 
   return (
     <FullscreenModal


### PR DESCRIPTION
### Description
- Add Truncate title to modal on mobile view
- Fixed popover info placement
- Fixed "score" styles
- Fixed "View all responses" button view

#### Related Pull Requests

- master - https://github.com/openedx/frontend-app-ora-grading/pull/336
- quince.master - https://github.com/openedx/frontend-app-ora-grading/pull/337
- redwood.master - https://github.com/openedx/frontend-app-ora-grading/pull/338

#### Screenshots before:
| <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/dc5c6e60-7de9-4ce8-b56e-76c1bb0420a5"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/d5bde3e4-b0f7-4327-ad07-46f81a742a15"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/aa94c9aa-9d52-499c-a8bf-14a2fe405730"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/5cdf31df-6c9c-409a-b32c-ededc204f768"> |
|---|---|---|---|

#### Screenshots after:
| <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/9d311dab-4cdd-47d7-959a-f78a1d708166"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/824e8793-bbfc-4999-8ab2-dba2e912e915"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/7c035bc1-5391-4da9-9fa0-d573f886ddfe"> | <img width="980" alt="image" src="https://github.com/openedx/frontend-app-ora-grading/assets/138868841/824e8793-bbfc-4999-8ab2-dba2e912e915"> |
|---|---|---|---|
