### PR TITLE
test: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node: [18.15, 20]
 
     steps:
     - name: Checkout
@@ -24,7 +21,7 @@ jobs:
       uses: actions/setup-node@v4
 # Because of node 18 bug (https://github.com/nodejs/node/issues/47563), Pinning node version 18.15 until the next release of node
       with:
-        node-version: ${{ matrix.node }}
+        node-version-file: '.nvmrc'
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Complete the upgrade to Node 20 by removing the Node 18 CI check and going back to using .nvmrc as the source of truth for which version to use.

See [the tracking issue](https://github.com/openedx/frontend-app-ora-grading/issues/319) for further information.