### PR TITLE
fix: Fix for the Paragon modal shadow, which prevents clicking on an elements on the grading page

### DIFF
--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -5,10 +5,8 @@
   overflow: auto !important;
   padding: inherit;
 
-  & > div.pgn__modal-body-content {
-    .row {
-      height: 100%;
-    }
+  & > div.pgn__modal-body-content .row {
+    height: 100%;
   }
 
   .content-block {


### PR DESCRIPTION
Minor issue was found on the "View all responses" modal window. This modal window is based on the Paragon Modal component, which has top and bottom shadows to indicate that there is some content at the top or bottom. These shadows are made with `:before` and `:after` pseudo-elements and should stick to the top and bottom. Example below:

https://github.com/user-attachments/assets/8a5dd60f-2f6c-4df2-97d6-a50d040a7f33

But in the Grading modal window, the bottom shadow "has a life of its own" and takes various positions on the page, sometimes covering different elements depending on the scroll position or browser window size. Sometimes it's impossible to click the submit button or select a grade.

In the example below, I colored the bottom pseudo-element `:after` in red for clarity, to demonstrate that it’s not sticking to the bottom of the page.

https://github.com/user-attachments/assets/b2ea7612-9b7f-470c-a507-f09146e24833

To fix this bug, it is necessary to remove the `height: 100%` property set for `.review-modal-body > div.pgn__modal-body-content`. This property was added in this commit: https://github.com/openedx/frontend-app-ora-grading/commit/dd880d4b44c2b28c2133d97abbce60a2a7d4d5f0

After I removed `height: 100%`, I didn’t notice any issues with other elements on the page. Perhaps @leangseu-edx could point out if there’s something I might have missed?

https://github.com/user-attachments/assets/ff59fb2c-09c2-43de-8bfb-fc726c04506f
