### PR TITLE
fix: convert notification banner to text if accounts url is not set

### DIFF
--- a/src/containers/NotificationsBanner/NotificationsBanner.test.jsx
+++ b/src/containers/NotificationsBanner/NotificationsBanner.test.jsx
@@ -1,10 +1,30 @@
 import React from 'react';
 import { shallow } from '@edx/react-unit-test-utils';
+import { getConfig } from '@edx/frontend-platform';
 
 import { NotificationsBanner } from '.';
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
+
 describe('NotificationsBanner component', () => {
-  test('snapshots', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('snapshots with empty ACCOUNT_SETTINGS_URL', () => {
+    getConfig.mockReturnValue({
+      ACCOUNT_SETTINGS_URL: '',
+    });
+    const el = shallow(<NotificationsBanner hide />);
+    expect(el.snapshot).toMatchSnapshot();
+  });
+
+  test('snapshots with ACCOUNT_SETTINGS_URL', () => {
+    getConfig.mockReturnValue({
+      ACCOUNT_SETTINGS_URL: 'http://localhost:1997',
+    });
     const el = shallow(<NotificationsBanner hide />);
     expect(el.snapshot).toMatchSnapshot();
   });

--- a/src/containers/NotificationsBanner/__snapshots__/NotificationsBanner.test.jsx.snap
+++ b/src/containers/NotificationsBanner/__snapshots__/NotificationsBanner.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotificationsBanner component snapshots 1`] = `
+exports[`NotificationsBanner component snapshots with ACCOUNT_SETTINGS_URL 1`] = `
 <PageBanner
   variant="accentB"
 >
@@ -24,6 +24,25 @@ exports[`NotificationsBanner component snapshots 1`] = `
         id="ora-grading.NotificationsBanner.linkMessage"
       />
     </Hyperlink>
+  </span>
+</PageBanner>
+`;
+
+exports[`NotificationsBanner component snapshots with empty ACCOUNT_SETTINGS_URL 1`] = `
+<PageBanner
+  variant="accentB"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="You can now enable notifications for ORA assignments that require staff grading, from the "
+      description="user info message that user can enable notifications for ORA assignments"
+      id="ora-grading.NotificationsBanner.Message"
+    />
+    <FormattedMessage
+      defaultMessage="preferences center."
+      description="placeholder for the preferences center link"
+      id="ora-grading.NotificationsBanner.linkMessage"
+    />
   </span>
 </PageBanner>
 `;

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -12,7 +12,7 @@ export const NotificationsBanner = () => (
     <span>
       <FormattedMessage {...messages.infoMessage} />
       {
-        _.isEmpty(getConfig().ACCOUNT_SETTINGS_URL) ? (
+        isEmpty(getConfig().ACCOUNT_SETTINGS_URL) ? (
           <FormattedMessage {...messages.notificationsBannerLinkMessage} />
         ) : (
           <Hyperlink

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -13,7 +13,7 @@ export const NotificationsBanner = () => (
       <FormattedMessage {...messages.infoMessage} />
       {
         isEmpty(getConfig().ACCOUNT_SETTINGS_URL) ? (
-          <FormattedMessage {...messages.notificationsBannerLinkMessage} />
+          <FormattedMessage {...messages.notificationsBannerPreferencesCenterMessage} />
         ) : (
           <Hyperlink
             isInline
@@ -23,7 +23,7 @@ export const NotificationsBanner = () => (
             rel="noopener noreferrer"
             showLaunchIcon={false}
           >
-            <FormattedMessage {...messages.notificationsBannerLinkMessage} />
+            <FormattedMessage {...messages.notificationsBannerPreferencesCenterMessage} />
           </Hyperlink>
         )
       }

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -10,16 +11,22 @@ export const NotificationsBanner = () => (
   <PageBanner variant="accentB">
     <span>
       <FormattedMessage {...messages.infoMessage} />
-      <Hyperlink
-        isInline
-        variant="muted"
-        destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
-        target="_blank"
-        rel="noopener noreferrer"
-        showLaunchIcon={false}
-      >
-        <FormattedMessage {...messages.notificationsBannerLinkMessage} />
-      </Hyperlink>
+      {
+        _.isEmpty(getConfig().ACCOUNT_SETTINGS_URL) ? (
+          <FormattedMessage {...messages.notificationsBannerLinkMessage} />
+        ) : (
+          <Hyperlink
+            isInline
+            variant="muted"
+            destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+            target="_blank"
+            rel="noopener noreferrer"
+            showLaunchIcon={false}
+          >
+            <FormattedMessage {...messages.notificationsBannerLinkMessage} />
+          </Hyperlink>
+        )
+      }
     </span>
   </PageBanner>
 );

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -12,21 +12,25 @@ export const NotificationsBanner = () => (
     <span>
       <FormattedMessage {...messages.infoMessage} />
       {
-        isEmpty(getConfig().ACCOUNT_SETTINGS_URL) ? (
+        (
+          getConfig().ACCOUNT_SETTINGS_URL === null
+            || getConfig().ACCOUNT_SETTINGS_URL === undefined
+            || getConfig().ACCOUNT_SETTINGS_URL.trim().length === 0
+        ) ? (
           <FormattedMessage {...messages.notificationsBannerPreferencesCenterMessage} />
-        ) : (
-          <Hyperlink
-            isInline
-            variant="muted"
-            destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
-            target="_blank"
-            rel="noopener noreferrer"
-            showLaunchIcon={false}
-          >
-            <FormattedMessage {...messages.notificationsBannerPreferencesCenterMessage} />
-          </Hyperlink>
-        )
-      }
+          ) : (
+            <Hyperlink
+              isInline
+              variant="muted"
+              destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+              target="_blank"
+              rel="noopener noreferrer"
+              showLaunchIcon={false}
+            >
+              <FormattedMessage {...messages.notificationsBannerPreferencesCenterMessage} />
+            </Hyperlink>
+          )
+        }
     </span>
   </PageBanner>
 );

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { isEmpty } from 'lodash';
 
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/containers/NotificationsBanner/messages.js
+++ b/src/containers/NotificationsBanner/messages.js
@@ -8,7 +8,7 @@ const messages = defineMessages({
     defaultMessage: 'You can now enable notifications for ORA assignments that require staff grading, from the ',
     description: 'user info message that user can enable notifications for ORA assignments',
   },
-  notificationsBannerLinkMessage: {
+  notificationsBannerPreferencesCenterMessage: {
     id: 'ora-grading.NotificationsBanner.linkMessage',
     defaultMessage: 'preferences center.',
     description: 'placeholder for the preferences center link',


### PR DESCRIPTION
## Description

The notification banner is always visible and cannot be dismissed. If ACCOUNT_SETTINGS_URL is not set, it redirects to `<ora_grading>/notifications`, which is not a valid URL.

This PR displays text instead of a link when the ACCOUNT_SETTINGS_URL is not set.

## Screenshots

Before:

<img width="1739" alt="Screenshot 2024-10-02 at 2 28 24 PM" src="https://github.com/user-attachments/assets/00ff77c2-454c-4d85-8f53-bf9d206028ef">

After (If ACCOUNT_SETTINGS_URL is not set):

<img width="1739" alt="Screenshot 2024-10-03 at 8 30 56 PM" src="https://github.com/user-attachments/assets/92a1a7a0-c45a-4bdf-9d21-d50297ebc0f3">


After (If ACCOUNT_SETTINGS_URL is set):

<img width="1739" alt="Screenshot 2024-10-03 at 8 27 47 PM" src="https://github.com/user-attachments/assets/c7b3f63f-89fa-4e68-820d-67093308a815">


