### PR TITLE
fix: update filesize package import to resolve build warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "dompurify": "^2.3.1",
         "email-prop-type": "^3.0.1",
         "file-saver": "^2.0.5",
-        "filesize": "^8.0.6",
+        "filesize": "^10.0.0",
         "font-awesome": "4.7.0",
         "history": "5.3.0",
         "html-react-parser": "^1.3.0",
@@ -10102,11 +10102,12 @@
       }
     },
     "node_modules/filesize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
+      "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==",
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 10.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -19094,6 +19095,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/filesize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dompurify": "^2.3.1",
     "email-prop-type": "^3.0.1",
     "file-saver": "^2.0.5",
-    "filesize": "^8.0.6",
+    "filesize": "^10.0.0",
     "font-awesome": "4.7.0",
     "history": "5.3.0",
     "html-react-parser": "^1.3.0",

--- a/src/components/FilePopoverContent/index.jsx
+++ b/src/components/FilePopoverContent/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import filesize from 'filesize';
+import { filesize } from 'filesize';
 
 import messages from './messages';
 

--- a/src/components/FilePopoverContent/index.test.jsx
+++ b/src/components/FilePopoverContent/index.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { shallow } from '@edx/react-unit-test-utils';
 
-import filesize from 'filesize';
+import { filesize } from 'filesize';
 import FilePopoverContent from '.';
 
-jest.mock('filesize', () => (size) => `filesize(${size})`);
+jest.mock('filesize', () => ({
+  filesize: (size) => `filesize(${size})`,
+}));
 
 describe('FilePopoverContent', () => {
   describe('component', () => {


### PR DESCRIPTION
This PR fixes the build warning introduced by Renovate PR #241 which updates filesize to v10.

The warning was:

WARNING in ./src/components/FilePopoverContent/index.jsx 34:66-74
export 'default' (imported as 'filesize') was not found in 'filesize' (possible exports: filesize, partial)
