### PR TITLE
fix: Adjust Review Modal Content Spacing

### DIFF
--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -5,8 +5,6 @@
   padding: inherit;
 
   & > div.pgn__modal-body-content {
-    height: 100%;
-
     .row {
       height: 100%;
     }


### PR DESCRIPTION
### Overview
Fix the review modal content spacing by removing the fixed height constraint that was causing content to stick to the bottom of the page.

### Changes
- Removed `height: 100%` property from `.pgn__modal-body-content` to allow natural content flow
- Improves visual presentation of the modal content with proper bottom spacing

### Screenshots
#### Before
![Screenshot from 2024-11-06 13-57-08](https://github.com/user-attachments/assets/324d6df8-23bd-4aa9-8178-34017021dfdb)


#### After
![Screenshot from 2024-11-06 13-57-45](https://github.com/user-attachments/assets/4cbcaeb3-370d-41d2-8202-0be2d666c214)
