### PR TITLE
chore(deps): update dependency redux-mock-store to 1.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "react-dev-utils": "^12.0.1",
         "react-test-renderer": "^17.0.2",
         "reactifex": "1.1.1",
-        "redux-mock-store": "^1.5.4",
+        "redux-mock-store": "^1.5.5",
         "semantic-release": "^19.0.3"
       }
     },
@@ -19889,12 +19889,15 @@
       }
     },
     "node_modules/redux-mock-store": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
-      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.5.tgz",
+      "integrity": "sha512-YxX+ofKUTQkZE4HbhYG4kKGr7oCTJfB0GLy7bSeqx86GLpGirrbUWstMnqXkqHNaQpcnbMGbof2dYs5KsPE6Zg==",
       "dev": true,
       "dependencies": {
         "lodash.isplainobject": "^4.0.6"
+      },
+      "peerDependencies": {
+        "redux": "*"
       }
     },
     "node_modules/redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-dev-utils": "^12.0.1",
     "react-test-renderer": "^17.0.2",
     "reactifex": "1.1.1",
-    "redux-mock-store": "^1.5.4",
+    "redux-mock-store": "^1.5.5",
     "semantic-release": "^19.0.3"
   }
 }


### PR DESCRIPTION
This PR updates the redux-mock-store dependency from 1.5.4 to 1.5.5 in both package.json and package-lock.json.

Package changes:
- redux-mock-store: 1.5.4 -> 1.5.5

Changes:
- Updated package.json to pin redux-mock-store to version 1.5.5
- Updated corresponding package-lock.json entries

This update ensures dependency consistency across the project files.

Note: This PR replaces the previous Renovate PR #364 to include updates to both package files.