### PR TITLE
fix: incorrect message for locking 

### DIFF
--- a/src/containers/ReviewModal/ReviewErrors/LockErrors.jsx
+++ b/src/containers/ReviewModal/ReviewErrors/LockErrors.jsx
@@ -16,7 +16,7 @@ import ReviewError from './ReviewError';
  */
 export class LockErrors extends React.Component {
   get errorProp() {
-    if (this.props.errorStatus === ErrorStatuses.forbidden) {
+    if (this.props.errorStatus === ErrorStatuses.conflict) {
       return {
         heading: messages.errorLockContestedHeading,
         message: messages.errorLockContested,

--- a/src/containers/ReviewModal/ReviewErrors/LockErrors.test.jsx
+++ b/src/containers/ReviewModal/ReviewErrors/LockErrors.test.jsx
@@ -41,7 +41,7 @@ describe('LockErrors component', () => {
         expect(el.snapshot).toMatchSnapshot();
       });
       test('snapshot: error with conflicted lock', () => {
-        el = shallow(<LockErrors {...props} errorStatus={ErrorStatuses.forbidden} />);
+        el = shallow(<LockErrors {...props} errorStatus={ErrorStatuses.conflict} />);
         expect(el.snapshot).toMatchSnapshot();
       });
     });


### PR DESCRIPTION
## Description:
Backport https://github.com/openedx/frontend-app-ora-grading/pull/326

### Reproduction steps:

1. Two Staff go to Instructors tab
2. Open responses and choose ORA
3. By each staff choose user answer
4. By first staff click on "Start grading" button
5. By second staff click on "Start grading" button

Then for the second Staff it will be displayed:
<img width="2042" alt="318108533-b751e0be-2a28-470c-860c-af6bb3ad839f" src="https://github.com/user-attachments/assets/bf48fe50-33ab-4ad5-adff-13be38d8c65c">
The message selection process was incorrect because a 409 was received from the server (as intended).

Now this message is displayed:
<img width="1041" alt="222" src="https://github.com/user-attachments/assets/3a18a31f-d39c-4b21-8c29-ba088a5cf70a">

