### PR TITLE
fix: Use browserslist-config [Sumac backport]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
-        "@edx/browserslist-config": "^1.2.0",
+        "@edx/browserslist-config": "^1.3.0",
         "@edx/react-unit-test-utils": "3.0.0",
         "@edx/reactifex": "^2.1.1",
         "@openedx/frontend-build": "14.0.3",
@@ -2048,10 +2048,11 @@
       "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@edx/browserslist-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.2.0.tgz",
-      "integrity": "sha512-T1+6P52Yx7SMkmoIr4O0Q3m/DyRdrLTJbv1xVijdRLFEq1hqdafEs+Ln1423U5LSkTePb9AOkEtL1G0RZLFl1w==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.3.0.tgz",
+      "integrity": "sha512-qf4BHyjdsx/bVMQmfj1y/MwTZwI5+9DAOul+PJnyO+YhWSwdxtdvXqkOw1wLxqmDtqOPc5bYgDQf8zZfe+aDFA==",
+      "dev": true,
+      "license": "AGPL-3.0"
     },
     "node_modules/@edx/eslint-config": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/edx/frontend-app-ora-grading.git"
   },
+  "browserslist": [
+    "extends @edx/browserslist-config"
+  ],
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "fedx-scripts formatjs extract",
@@ -72,7 +75,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
-    "@edx/browserslist-config": "^1.2.0",
+    "@edx/browserslist-config": "^1.3.0",
     "@edx/react-unit-test-utils": "3.0.0",
     "@edx/reactifex": "^2.1.1",
     "@openedx/frontend-build": "14.0.3",

--- a/src/data/redux/thunkActions/download.test.js
+++ b/src/data/redux/thunkActions/download.test.js
@@ -6,9 +6,9 @@ import { RequestKeys } from 'data/constants/requests';
 import api from 'data/services/lms/api';
 import * as download from './download';
 
-const mockBlobWriter = jest.fn().mockName('BlobWriter');
-const mockTextReader = jest.fn().mockName('TextReader');
-const mockBlobReader = jest.fn().mockName('BlobReader');
+const mockBlobWriter = jest.fn();
+const mockTextReader = jest.fn();
+const mockBlobReader = jest.fn();
 
 const mockZipAdd = jest.fn();
 const mockZipClose = jest.fn();
@@ -21,9 +21,9 @@ jest.mock('@zip.js/zip.js', () => {
       close: mockZipClose.mockImplementation(() => Promise.resolve(files)),
       files,
     })),
-    BlobWriter: () => mockBlobWriter,
-    TextReader: () => mockTextReader,
-    BlobReader: () => mockBlobReader,
+    BlobWriter: function _() { return mockBlobWriter; },
+    TextReader: function _() { return mockTextReader; },
+    BlobReader: function _() { return mockBlobReader; },
   };
 });
 


### PR DESCRIPTION
(This is a backport of #379 to Sumac.)

We were installing browserslist-config but not declaring it (as per [the documentation](https://github.com/browserslist/browserslist?tab=readme-ov-file#browserslist-) and [frontend-template-application](https://github.com/openedx/frontend-template-application/blob/master/package.json#L9-L11)).  This had the effect that webpack - and likely others - were not using it.

For those curious, we discovered this by way of trying to get this to work: https://github.com/overhangio/tutor-indigo/pull/109#discussion_r1872099134.