### PR TITLE
fix: updated notifications preferences url

### DIFF
--- a/src/containers/NotificationsBanner/__snapshots__/NotificationsBanner.test.jsx.snap
+++ b/src/containers/NotificationsBanner/__snapshots__/NotificationsBanner.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`NotificationsBanner component snapshots with ACCOUNT_SETTINGS_URL 1`] =
       id="ora-grading.NotificationsBanner.Message"
     />
     <Hyperlink
-      destination="http://localhost:1997/notifications"
+      destination="http://localhost:1997/#notifications"
       isInline={true}
       rel="noopener noreferrer"
       showLaunchIcon={false}

--- a/src/containers/NotificationsBanner/index.jsx
+++ b/src/containers/NotificationsBanner/index.jsx
@@ -21,7 +21,7 @@ export const NotificationsBanner = () => (
             <Hyperlink
               isInline
               variant="muted"
-              destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+              destination={`${getConfig().ACCOUNT_SETTINGS_URL}/#notifications`}
               target="_blank"
               rel="noopener noreferrer"
               showLaunchIcon={false}


### PR DESCRIPTION
Description
Updated the notifications preferences section URL which is used on different MFEs to redirect the user to the notifications preferences center.

Old URL: https://account.edx.org/notifications
New URL: https://account.edx.org/#notifications