### PR TITLE
feat: ORA visual improvements

### DIFF
--- a/src/containers/Rubric/Rubric.scss
+++ b/src/containers/Rubric/Rubric.scss
@@ -19,15 +19,19 @@
   }
 }
 .criteria-option {
+  display: flex;
   width: 100%;
   > div {
-    display: inline;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
     width: 100%;
     .pgn__form-label {
       display: inline-flex;
+      padding-right: 10px;
     }
     .pgn__form-control-description {
-      float: right;
+      white-space: nowrap;
     }
   }
 }
@@ -41,6 +45,10 @@
   margin-right: map-get($spacers, 1) !important;
   .help-popover-option {
     margin-bottom: map-get($spacers, 1);
+  }
+  .popover-body {
+    max-height: 100vh;
+    overflow-y: auto !important;
   }
 }
 


### PR DESCRIPTION
This PR introduces a few visual enhancements:

1. If the criterion name is too long - points are not displayed in a user-friendly way

Screen before:

![Знімок екрана 2023-11-13 о 16 51 29](https://github.com/user-attachments/assets/4ad50187-700d-4626-9698-ab5bd0cd0aed)

![Знімок екрана 2023-11-13 о 17 00 17](https://github.com/user-attachments/assets/82ada4f8-9b7b-41bd-96af-7dd167ece69e)

Screen after:

<img width="1840" alt="Снимок экрана 2025-03-31 в 13 28 35" src="https://github.com/user-attachments/assets/6671bb8c-31c2-46fa-889f-8eea501d1305" />

<img width="1840" alt="Снимок экрана 2025-03-31 в 13 30 49" src="https://github.com/user-attachments/assets/0c42b5a6-99b7-4f42-9079-d5b2aa660ee3" />

2. A too-long popover with explanation text gets cut off if it doesn’t fit within the window height and cannot be scrolled

Screen before:

<img width="1840" alt="Снимок экрана 2025-03-31 в 19 00 45" src="https://github.com/user-attachments/assets/ab8febdf-8861-4331-b7af-1be212575adb" />

Video after:

https://github.com/user-attachments/assets/de00f118-cfad-4b25-adcc-be4c740c6fd6
