### PR TITLE
fix: ignore deleted files in submissions

### DIFF
--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -52,7 +52,15 @@ const fetchSubmission = (submissionUUID) => get(
     [paramKeys.oraLocation]: locationId(),
     [paramKeys.submissionUUID]: submissionUUID,
   }),
-).then(response => response.data);
+).then(response => ({
+  ...response.data,
+  response: {
+    ...response.data.response,
+    // The API includes metadata for deleted files (without a download url);
+    // we don't want to deal with deleted files here, so filter them out like the student view does.
+    files: response.data.response.files.filter((file) => file.downloadUrl),
+  },
+}));
 
 /**
  * get('/api/submission/files', { oraLocation, submissionUUID })
@@ -65,7 +73,12 @@ const fetchSubmissionFiles = (submissionUUID) => get(
     [paramKeys.oraLocation]: locationId(),
     [paramKeys.submissionUUID]: submissionUUID,
   }),
-).then(response => response.data);
+).then(response => ({
+  ...response.data,
+  // The API includes metadata for deleted files (without a download url);
+  // we don't want to deal with deleted files here, so filter them out like the student view does.
+  files: response.data.files.filter((file) => file.downloadUrl),
+}));
 
 /**
  * fetches the current grade, gradeStatus, and rubricResponse data for the given submission


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description


If a file is deleted from disk somehow after the student response has been submitted, the api will still respond with metadata about these files. However, the download url will be empty, resulting in broken files in the frontend ui: the preview pane will display an "Unknown error", and downloading the files will result in downloaded files with the correct file names but invalid content.

The student view in ORA handles these deleted files by simply ignoring them and not displaying them to the user. So here we do the same: simply filter out any deleted files from the api.

---

Screenshots of the UI before:

<img width="971" height="1637" alt="1753690484" src="https://github.com/user-attachments/assets/a4f6b1a5-b3c7-451c-bbe0-c2188ad7ed65" />


and after:

<img width="964" height="1367" alt="1753690602" src="https://github.com/user-attachments/assets/9a461c53-49a9-433f-a161-34d4eafc83ad" />



## Supporting information

none

## Testing instructions

1. Deploy this frontend app and create a test open edx course containing an ora block with a file upload field.
2. Navigate to the ora block, upload two previewable files (eg. pdf or image files), click submit, and then click confirm.
3. Then as fast as you can, click 'delete' next to one of the uploaded files in the UI (while the submission is still processing), and hit enter to accept the confirmation popup. This exploits a race condition in the UI - I think users on slow internet connections may run into this more often.
4. Refresh the page and view your submission in the same student view of the ora block.
5. Verify that only one uploaded file is displayed (not the file that was deleted).
6. Navigate to the ora grading view for this ora block.
7. View the submission for your user.


Without this patch:

- Verify that you see both files in the submission.
- Verify that the file preview for the file you deleted shows an "Unknown errors" error message (while the other one should succeed).
- Download the submission files as a zip, unzip it, and verify that the file contents is invalid (it will be html, from the ora-grading app).

With this patch:

- Verify that you see only one uploaded file, and that is successfully displayed in the preview pane.
- Download the files as a zip from the UI, unzip them, and verify that the manifest only shows the one file, and that the file included is valid and the file you uploaded (not the one you deleted).
- Verify that there are no related errors.

## Deadline

None

## Other information

This is a minor frontend change only, so it shouldn't affect backwards compatibility.
The behaviour change is also in line with how the ORA block works already for the existing views.

Private-ref: https://tasks.opencraft.com/browse/BB-9781
