### PR TITLE
build: remove unused reactifex packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.3.0",
-        "@edx/reactifex": "^2.1.1",
         "@openedx/frontend-build": "^14.6.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -70,7 +69,6 @@
         "jest-expect-message": "^1.0.2",
         "react-dev-utils": "^12.0.1",
         "react-test-renderer": "^18.3.1",
-        "reactifex": "1.1.1",
         "redux-mock-store": "^1.5.5"
       }
     },
@@ -2676,30 +2674,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.2.0.tgz",
-      "integrity": "sha512-vyGDtx3BwCr6Gjbm4y6gJ8Bzc2TOSNBlBa2hMerz59HoXaot14MihxxiDU+JDNybGLLcKDBiK511bOi/77i1lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {
@@ -18948,16 +18922,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "reactifex": "main.js"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.3.0",
-    "@edx/reactifex": "^2.1.1",
     "@openedx/frontend-build": "^14.6.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
@@ -88,7 +87,6 @@
     "jest-expect-message": "^1.0.2",
     "react-dev-utils": "^12.0.1",
     "react-test-renderer": "^18.3.1",
-    "reactifex": "1.1.1",
     "redux-mock-store": "^1.5.5"
   }
 }


### PR DESCRIPTION
Remove reactifex and @edx/reactifex packages from devDependencies as they are no longer
needed. Translation extraction functionality has been verified to work
correctly without these dependencies.

Co-Authored-By: Claude <noreply@anthropic.com>
