### PR TITLE
fix(ReviewModal): remove obsolete "Grading Demo" title suffix

### DIFF
--- a/src/containers/ReviewModal/hooks.js
+++ b/src/containers/ReviewModal/hooks.js
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { StrictDict } from 'utils';
 import { selectors, thunkActions } from 'data/redux';
 import { RequestKeys } from 'data/constants/requests';
-import messages from './messages';
 import * as module from './hooks';
 
 export const state = StrictDict({
@@ -16,7 +15,6 @@ export const reduxValues = () => ({
     selectors.requests.errorStatus(val, { requestKey: RequestKeys.fetchSubmission })
   )),
   hasGradingProgress: useSelector(selectors.grading.hasGradingProgress),
-  isEnabled: useSelector(selectors.app.isEnabled),
   isLoaded: useSelector((val) => (
     selectors.requests.isCompleted(val, { requestKey: RequestKeys.fetchSubmission })
   )),
@@ -26,14 +24,12 @@ export const reduxValues = () => ({
 
 export const rendererHooks = ({
   dispatch,
-  intl: { formatMessage },
 }) => {
   const [show, setShow] = state.showConfirmCloseReviewGrade(false);
 
   const {
     errorStatus,
     hasGradingProgress,
-    isEnabled,
     isLoaded,
     isOpen,
     oraName,
@@ -50,9 +46,7 @@ export const rendererHooks = ({
   return {
     onClose,
     isLoading: !(errorStatus || isLoaded),
-    title: isEnabled
-      ? `${oraName} - ${formatMessage(messages.demoTitleMessage)}`
-      : oraName,
+    title: oraName,
     isOpen,
     closeConfirmModalProps: {
       isOpen: show,

--- a/src/containers/ReviewModal/hooks.test.js
+++ b/src/containers/ReviewModal/hooks.test.js
@@ -1,10 +1,9 @@
 import { useSelector } from 'react-redux';
 
 import { keyStore } from 'utils';
-import { MockUseState, formatMessage } from 'testUtils';
+import { MockUseState } from 'testUtils';
 import { selectors, thunkActions } from 'data/redux';
 import { RequestKeys } from 'data/constants/requests';
-import messages from './messages';
 
 import * as hooks from './hooks';
 
@@ -14,7 +13,6 @@ jest.useFakeTimers('modern');
 jest.mock('data/redux', () => ({
   selectors: {
     app: {
-      isEnabled: (args) => ({ isEnabled: args }),
       ora: { name: (...args) => ({ oraName: args }) },
       showReview: (...args) => ({ showReview: args }),
     },
@@ -49,7 +47,6 @@ const requestKey = RequestKeys.fetchSubmission;
 const hookKeys = keyStore(hooks);
 
 const testState = { my: 'test-state' };
-const intl = { formatMessage };
 const dispatch = jest.fn();
 describe('ReviewModal hooks', () => {
   beforeEach(() => {
@@ -75,9 +72,6 @@ describe('ReviewModal hooks', () => {
     test('hasGradingProgress loads grading.hasGradingProgress', () => {
       testSelector(reduxKeys.hasGradingProgress, selectors.grading.hasGradingProgress);
     });
-    test('isEnabled loads app.isEnabled', () => {
-      testSelector(reduxKeys.isEnabled, selectors.app.isEnabled);
-    });
     test('isLoaded loads if fetchSubmission is complete', () => {
       testRequestSelector(reduxKeys.isLoaded, selectors.requests.isCompleted);
     });
@@ -97,7 +91,6 @@ describe('ReviewModal hooks', () => {
     const reduxValues = {
       errorStatus: null,
       hasGradingProgress: false,
-      isEnabled: false,
       isLoaded: false,
       isOpen: false,
       oraName: 'ora-NAAAAMME',
@@ -110,7 +103,7 @@ describe('ReviewModal hooks', () => {
     };
     const loadHook = (newVals) => {
       mockRedux(newVals);
-      return hooks.rendererHooks({ dispatch, intl });
+      return hooks.rendererHooks({ dispatch });
     };
     describe('rendererHooks - returned object:', () => {
       let hook;
@@ -134,13 +127,9 @@ describe('ReviewModal hooks', () => {
         hook = loadHook({ isLoaded: true });
         expect(hook.isLoading).toEqual(false);
       });
-      test('title is ora name, with appended demo title message if isEnabled', () => {
+      test('title is the ora name', () => {
         hook = loadHook({});
         expect(hook.title).toEqual(reduxValues.oraName);
-        hook = loadHook({ isEnabled: true });
-        expect(hook.title).toEqual(
-          [reduxValues.oraName, formatMessage(messages.demoTitleMessage)].join(' - '),
-        );
       });
       test('isOpen is loaded from redux value, defaulted to false', () => {
         expect(loadHook({}).isOpen).toEqual(false);

--- a/src/containers/ReviewModal/index.jsx
+++ b/src/containers/ReviewModal/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import { FullscreenModal, Truncate, useMediaQuery } from '@openedx/paragon';
-import { useIntl } from '@edx/frontend-platform/i18n';
 
 import LoadingMessage from 'components/LoadingMessage';
 import DemoWarning from 'containers/DemoWarning';
@@ -19,7 +18,6 @@ import './ReviewModal.scss';
  * <ReviewModal />
  */
 export const ReviewModal = () => {
-  const intl = useIntl();
   const dispatch = useDispatch();
   const {
     isLoading,
@@ -27,7 +25,7 @@ export const ReviewModal = () => {
     onClose,
     isOpen,
     closeConfirmModalProps,
-  } = hooks.rendererHooks({ dispatch, intl });
+  } = hooks.rendererHooks({ dispatch });
 
   const isMobile = useMediaQuery({ query: '(max-width: 768px)' });
 

--- a/src/containers/ReviewModal/index.test.jsx
+++ b/src/containers/ReviewModal/index.test.jsx
@@ -42,7 +42,7 @@ describe('ReviewModal', () => {
     useDispatch.mockReturnValue(mockDispatch);
   });
 
-  it('calls rendererHooks with dispatch and intl', () => {
+  it('calls rendererHooks with dispatch', () => {
     hooks.rendererHooks.mockReturnValue({
       isLoading: false,
       title: 'test-ora-name',
@@ -59,7 +59,6 @@ describe('ReviewModal', () => {
 
     expect(hooks.rendererHooks).toHaveBeenCalledWith({
       dispatch: mockDispatch,
-      intl: expect.any(Object),
     });
   });
 

--- a/src/containers/ReviewModal/messages.js
+++ b/src/containers/ReviewModal/messages.js
@@ -7,11 +7,6 @@ const messages = defineMessages({
     defaultMessage: 'Loading response',
     description: 'loading text for submission response review screen',
   },
-  demoTitleMessage: {
-    id: 'ora-grading.ReviewModal.demoTitleMessage',
-    defaultMessage: 'Grading Demo',
-    description: 'message added to modal title, indicating grading demo',
-  },
 });
 
 export default StrictDict(messages);


### PR DESCRIPTION
## Description

The ORA review modal title unconditionally appended "Grading Demo" whenever `isEnabled` was true. That label dates back to the 2022 ESG opt-in rollout, when the ORA staff area linked out to this MFE as a separate, read-only "Demo the new Grading Experience" preview. This MFE has since become the default grading experience, so the suffix is stale and misleading rather than something to fix by flipping the condition — it's removed outright.

## Changes
- `ReviewModal`: title now always renders as the plain ORA name, no conditional suffix
- Removed the now-dead `isEnabled` selector and `useIntl`/`formatMessage` plumbing threaded through `hooks.js` and `index.jsx`
- Removed the unused `demoTitleMessage` from `messages.js`
- Updated tests that previously asserted the old (incorrect) title-suffix behavior

## Screenshot
<img width="1417" height="738" alt="image (7)" src="https://github.com/user-attachments/assets/40bbb12c-1229-46ac-a947-4d36ed9cba88" />
